### PR TITLE
Add stereo toggle and locational jukebox sounds

### DIFF
--- a/core/src/main/java/dev/geco/gmusic/model/PlaySettings.java
+++ b/core/src/main/java/dev/geco/gmusic/model/PlaySettings.java
@@ -8,6 +8,7 @@ public class PlaySettings {
 	private final UUID uuid;
 	private PlayListMode playlistMode;
 	private int volume;
+	private boolean stereo;
 	private boolean playOnJoin;
 	private PlayMode playMode;
 	private boolean showParticles;
@@ -21,6 +22,7 @@ public class PlaySettings {
 			UUID uuid,
 			PlayListMode playlistMode,
 			int volume,
+			boolean stereo,
 			boolean playOnJoin,
 			PlayMode playMode,
 			boolean showParticles,
@@ -33,6 +35,7 @@ public class PlaySettings {
 		this.uuid = uuid;
 		this.playlistMode = playlistMode;
 		this.volume = volume;
+		this.stereo = stereo;
 		this.playOnJoin = playOnJoin;
 		this.playMode = playMode;
 		this.showParticles = showParticles;
@@ -54,6 +57,10 @@ public class PlaySettings {
 	public float getFixedVolume() { return (float) (volume * 2) / 100; }
 
 	public void setVolume(int volume) { this.volume = volume; }
+
+	public boolean isStereo() { return stereo; }
+
+	public void setStereo(boolean stereo) { this.stereo = stereo; }
 
 	public boolean isPlayOnJoin() { return playOnJoin; }
 

--- a/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
+++ b/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
@@ -157,9 +157,9 @@ public class MusicGUI {
 									gMusicMain.getRadioService().playSong(gMusicMain.getRadioService().getNextSong());
 								}
 							}
-						} else if(type != MenuType.RADIO) {
-							playSettings.setShowParticles(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_PARTICLES : !playSettings.isShowingParticles());
-							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-particle", "%Particle%", gMusicMain.getMessageService().getMessage(playSettings.isShowingParticles() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+						} else if(type != MenuType.RADIO && !(type == MenuType.JUKEBOX && gMusicMain.getConfigService().LOCATIONAL_JUKEBOX_SOUNDS)) {
+							playSettings.setStereo(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_STEREO : !playSettings.isStereo());
+							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-stereo", "%Stereo%", gMusicMain.getMessageService().getMessage(playSettings.isStereo() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
 						}
 					}
 					case 48 -> {
@@ -180,8 +180,8 @@ public class MusicGUI {
 								}
 							}
 						} else if(type != MenuType.RADIO) {
-							playSettings.setPlayOnJoin(click == ClickType.MIDDLE ? gMusicMain.getConfigService().R_PLAY_ON_JOIN : !playSettings.isPlayOnJoin());
-							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-join", "%Join%", gMusicMain.getMessageService().getMessage(playSettings.isPlayOnJoin() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+							playSettings.setShowParticles(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_PARTICLES : !playSettings.isShowingParticles());
+							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-particle", "%Particle%", gMusicMain.getMessageService().getMessage(playSettings.isShowingParticles() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
 						}
 					}
 					case 49 -> {
@@ -216,12 +216,9 @@ public class MusicGUI {
 								}
 							}
 							setDefaultBar();
-						} else {
-							if(playSettings.getPlayListMode() == PlayListMode.RADIO) return;
-							int playModeId = playSettings.getPlayMode().getId();
-							PlayMode playMode = PlayMode.byId(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_PLAY_MODE : (click == ClickType.RIGHT ? (playModeId - 1 < 0 ? PlayMode.values().length - 1 : playModeId - 1) : (playModeId + 1 > PlayMode.values().length - 1 ? 0 : playModeId + 1)));
-							playSettings.setPlayMode(playMode);
-							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage(playMode == PlayMode.DEFAULT ? "MusicGUI.music-options-play-mode-once" : playMode == PlayMode.SHUFFLE ? "MusicGUI.music-options-play-mode-shuffle" : "MusicGUI.music-options-play-mode-repeat"));
+						} else if(type != MenuType.RADIO) {
+							playSettings.setPlayOnJoin(click == ClickType.MIDDLE ? gMusicMain.getConfigService().R_PLAY_ON_JOIN : !playSettings.isPlayOnJoin());
+							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-join", "%Join%", gMusicMain.getMessageService().getMessage(playSettings.isPlayOnJoin() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
 						}
 					}
 					case 50 -> {
@@ -229,8 +226,10 @@ public class MusicGUI {
 							setOptionsBar();
 						} else {
 							if(playSettings.getPlayListMode() == PlayListMode.RADIO) return;
-							playSettings.setReverseMode(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_REVERSE : !playSettings.isReverseMode());
-							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-reverse", "%Reverse%", gMusicMain.getMessageService().getMessage(playSettings.isReverseMode() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+							int playModeId = playSettings.getPlayMode().getId();
+							PlayMode playMode = PlayMode.byId(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_PLAY_MODE : (click == ClickType.RIGHT ? (playModeId - 1 < 0 ? PlayMode.values().length - 1 : playModeId - 1) : (playModeId + 1 > PlayMode.values().length - 1 ? 0 : playModeId + 1)));
+							playSettings.setPlayMode(playMode);
+							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage(playMode == PlayMode.DEFAULT ? "MusicGUI.music-options-play-mode-once" : playMode == PlayMode.SHUFFLE ? "MusicGUI.music-options-play-mode-shuffle" : "MusicGUI.music-options-play-mode-repeat"));
 						}
 					}
 					case 51 -> {
@@ -259,7 +258,17 @@ public class MusicGUI {
 								setDefaultBar();
 							}
 						} else {
+							if(playSettings.getPlayListMode() == PlayListMode.RADIO) return;
+							playSettings.setReverseMode(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_REVERSE : !playSettings.isReverseMode());
+							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-reverse", "%Reverse%", gMusicMain.getMessageService().getMessage(playSettings.isReverseMode() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+						}
+					}
+					case 52 -> {
+						if(!optionState) {
+							setPage(page - 1);
+						} else {
 							if(type != MenuType.JUKEBOX) return;
+							if(gMusicMain.getConfigService().LOCATIONAL_JUKEBOX_SOUNDS) return;
 							long range = playSettings.getRange();
 							long step = click == ClickType.SHIFT_LEFT || click == ClickType.SHIFT_RIGHT ? SHIFT_RANGE_STEPS : RANGE_STEPS;
 							long newRange = click == ClickType.MIDDLE ? gMusicMain.getConfigService().JUKEBOX_RANGE : (click == ClickType.RIGHT ? Math.max(range - step, 0) : Math.min(range + step, gMusicMain.getConfigService().MAX_JUKEBOX_RANGE));
@@ -267,8 +276,11 @@ public class MusicGUI {
 							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-range", "%Range%", "" + newRange));
 						}
 					}
-					case 52 -> setPage(page - 1);
-					case 53 -> setPage(page + 1);
+					case 53 -> {
+						if(!optionState) {
+							setPage(page + 1);
+						}
+					}
 					default -> {
 						if(slot < 0 || slot > 44) return;
 						Song song = pageSongs.get(slot);
@@ -381,6 +393,7 @@ public class MusicGUI {
 		}
 
 		setPauseResumeBar();
+		setNavigationBar();
 	}
 
 	public void setPauseResumeBar() {
@@ -435,12 +448,19 @@ public class MusicGUI {
 			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-volume", "%Volume%", "" + playSettings.getVolume()));
 			itemStack.setItemMeta(itemMeta);
 			inventory.setItem(46, itemStack);
+			if(!(type == MenuType.JUKEBOX && gMusicMain.getConfigService().LOCATIONAL_JUKEBOX_SOUNDS)) {
+				itemStack = new ItemStack(Material.EMERALD);
+				itemMeta = itemStack.getItemMeta();
+				itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-stereo", "%Stereo%", gMusicMain.getMessageService().getMessage(playSettings.isStereo() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+				itemStack.setItemMeta(itemMeta);
+				inventory.setItem(47, itemStack);
+			}
 			itemStack = new ItemStack(Material.FIREWORK_ROCKET);
 			itemMeta = itemStack.getItemMeta();
 			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-particle", "%Particle%", gMusicMain.getMessageService().getMessage(playSettings.isShowingParticles() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
 			itemMeta.addItemFlags(ItemFlag.values());
 			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(47, itemStack);
+			inventory.setItem(48, itemStack);
 		}
 
 		if(playSettings.getPlayListMode() != PlayListMode.RADIO) {
@@ -449,26 +469,26 @@ public class MusicGUI {
 				itemMeta = itemStack.getItemMeta();
 				itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-join", "%Join%", gMusicMain.getMessageService().getMessage(playSettings.isPlayOnJoin() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
 				itemStack.setItemMeta(itemMeta);
-				inventory.setItem(48, itemStack);
+				inventory.setItem(49, itemStack);
 				itemStack = new ItemStack(Material.BLAZE_POWDER);
 				itemMeta = itemStack.getItemMeta();
 				itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage(playSettings.getPlayMode() == PlayMode.DEFAULT ? "MusicGUI.music-options-play-mode-once" : playSettings.getPlayMode() == PlayMode.SHUFFLE ? "MusicGUI.music-options-play-mode-shuffle" : "MusicGUI.music-options-play-mode-repeat"));
 				itemStack.setItemMeta(itemMeta);
-				inventory.setItem(49, itemStack);
+				inventory.setItem(50, itemStack);
 			}
 			itemStack = new ItemStack(Material.TOTEM_OF_UNDYING);
 			itemMeta = itemStack.getItemMeta();
 			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-reverse", "%Reverse%", gMusicMain.getMessageService().getMessage(playSettings.isReverseMode() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
 			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(50, itemStack);
+			inventory.setItem(51, itemStack);
 		}
 
-		if(type == MenuType.JUKEBOX) {
+		if(type == MenuType.JUKEBOX && !gMusicMain.getConfigService().LOCATIONAL_JUKEBOX_SOUNDS) {
 			itemStack = new ItemStack(Material.REDSTONE);
 			itemMeta = itemStack.getItemMeta();
 			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-range", "%Range%", "" + playSettings.getRange()));
 			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(51, itemStack);
+			inventory.setItem(52, itemStack);
 		}
 	}
 
@@ -510,6 +530,17 @@ public class MusicGUI {
 				itemStack.setItemMeta(itemMeta);
 				inventory.setItem(songPosition % 45, itemStack);
 			}
+		}
+
+		setNavigationBar();
+	}
+
+	private void setNavigationBar() {
+		List<Song> songs = new ArrayList<>();
+
+		if(playSettings.getPlayListMode() != PlayListMode.RADIO) {
+			songs = playSettings.getPlayListMode() == PlayListMode.FAVORITES ? playSettings.getFavorites() : gMusicMain.getSongService().getSongs();
+			if(searchKey != null && !searchKey.isEmpty()) songs = gMusicMain.getSongService().filterSongsBySearch(songs, searchKey);
 		}
 
 		if(page > 1) {

--- a/core/src/main/java/dev/geco/gmusic/service/ConfigService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/ConfigService.java
@@ -19,6 +19,7 @@ public class ConfigService {
     public boolean CHECK_FOR_UPDATE;
     public boolean S_EXTENDED_RANGE;
     public boolean S_FORCE_RESOURCES;
+    public boolean LOCATIONAL_JUKEBOX_SOUNDS;
     public int JUKEBOX_RANGE;
     public int MAX_JUKEBOX_RANGE;
     public boolean A_SHOW_MESSAGES;
@@ -34,6 +35,7 @@ public class ConfigService {
     public boolean PS_SAVE_ON_QUIT;
     public int PS_D_PLAYLIST_MODE;
     public int PS_D_VOLUME;
+    public boolean PS_D_STEREO;
     public boolean PS_D_JOIN;
     public int PS_D_PLAY_MODE;
     public boolean PS_D_PARTICLES;
@@ -81,6 +83,7 @@ public class ConfigService {
         S_EXTENDED_RANGE = gMusicMain.getConfig().getBoolean("Options.Sound.extened-range", true);
         S_FORCE_RESOURCES = gMusicMain.getConfig().getBoolean("Options.Sound.force-resources", true);
 
+        LOCATIONAL_JUKEBOX_SOUNDS = gMusicMain.getConfig().getBoolean("Options.locational-jukebox-sounds", true);
         JUKEBOX_RANGE = gMusicMain.getConfig().getInt("Options.jukebox-range", 50);
         MAX_JUKEBOX_RANGE = gMusicMain.getConfig().getInt("Options.max-jukebox-range", 500);
 
@@ -100,6 +103,7 @@ public class ConfigService {
         PS_SAVE_ON_QUIT = gMusicMain.getConfig().getBoolean("Options.PlayerSettings.save-on-quit", true);
         PS_D_PLAYLIST_MODE = gMusicMain.getConfig().getInt("Options.PlayerSettings.Default.playlist-mode", 0);
         PS_D_VOLUME = gMusicMain.getConfig().getInt("Options.PlayerSettings.Default.volume", 70);
+        PS_D_STEREO = gMusicMain.getConfig().getBoolean("Options.PlayerSettings.Default.stereo", true);
         PS_D_JOIN = gMusicMain.getConfig().getBoolean("Options.PlayerSettings.Default.join", false);
         PS_D_PLAY_MODE = gMusicMain.getConfig().getInt("Options.PlayerSettings.Default.play-mode", 0);
         PS_D_PARTICLES = gMusicMain.getConfig().getBoolean("Options.PlayerSettings.Default.particles", false);

--- a/core/src/main/java/dev/geco/gmusic/service/JukeBoxService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/JukeBoxService.java
@@ -226,7 +226,7 @@ public class JukeBoxService {
 							if(notePart.getSound() != null) {
 								float volume = (float) ((playersInRange.get(player) - playSettings.getRange()) * playSettings.getFixedVolume() / (double) -playSettings.getRange()) * notePart.getVolume();
 
-								Location location = notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
+								Location location = gMusicMain.getConfigService().LOCATIONAL_JUKEBOX_SOUNDS ? boxLocation : notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
 
 								if(!gMusicMain.getConfigService().ENVIRONMENT_EFFECTS) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
 								else {

--- a/core/src/main/java/dev/geco/gmusic/service/PlayService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/PlayService.java
@@ -99,7 +99,7 @@ public class PlayService {
 						if(notePart.getSound() != null) {
 							float volume = playSettings.getFixedVolume() * notePart.getVolume();
 
-							Location location = notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
+							Location location = playSettings.isStereo() || notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
 
 							if(!gMusicMain.getConfigService().ENVIRONMENT_EFFECTS) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
 							else {

--- a/core/src/main/java/dev/geco/gmusic/service/PlaySettingsService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/PlaySettingsService.java
@@ -28,6 +28,7 @@ public class PlaySettingsService {
 	public void createDataTables() {
 		try {
 			gMusicMain.getDataService().execute("CREATE TABLE IF NOT EXISTS gmusic_play_settings (uuid TEXT, playListMode INTEGER, volume INTEGER, playOnJoin INTEGER, playMode INTEGER, showParticles INTEGER, reverseMode INTEGER, toggleMode INTEGER, range INTEGER, currentSong TEXT);");
+			gMusicMain.getDataService().execute("CREATE TABLE IF NOT EXISTS gmusic_play_settings_stereo (uuid TEXT, stereo INTEGER);");
 			gMusicMain.getDataService().execute("CREATE TABLE IF NOT EXISTS gmusic_play_settings_favorites (uuid TEXT, songId TEXT);");
 		} catch(Throwable e) { gMusicMain.getLogger().log(Level.SEVERE, "Could not create play settings database tables!", e); }
 	}
@@ -36,6 +37,7 @@ public class PlaySettingsService {
 		if(playSettingsCache.containsKey(uuid)) return playSettingsCache.get(uuid);
 
 		List<Song> favorites = new ArrayList<>();
+		boolean stereo = true;
 
 		PlaySettings playSettings = null;
 
@@ -46,12 +48,19 @@ public class PlaySettingsService {
 				}
 			}
 
+			try(ResultSet playSettingsStereoData = gMusicMain.getDataService().executeAndGet("SELECT * FROM gmusic_play_settings_stereo WHERE uuid = ?", uuid.toString())) {
+				if(playSettingsStereoData.next()) {
+					stereo = playSettingsStereoData.getBoolean("stereo");
+				}
+			}
+
 			try(ResultSet playSettingsData = gMusicMain.getDataService().executeAndGet("SELECT * FROM gmusic_play_settings WHERE uuid = ?", uuid.toString())) {
 				if(playSettingsData.next()) {
 					playSettings = new PlaySettings(
 							uuid,
 							PlayListMode.byId(playSettingsData.getInt("playListMode")),
 							playSettingsData.getInt("volume"),
+							stereo,
 							playSettingsData.getBoolean("playOnJoin"),
 							PlayMode.byId(playSettingsData.getInt("playMode")),
 							playSettingsData.getBoolean("showParticles"),
@@ -78,6 +87,7 @@ public class PlaySettingsService {
 				uuid,
 				PlayListMode.byId(gMusicMain.getConfigService().PS_D_PLAYLIST_MODE),
 				gMusicMain.getConfigService().PS_D_VOLUME,
+				gMusicMain.getConfigService().PS_D_STEREO,
 				gMusicMain.getConfigService().R_PLAY_ON_JOIN,
 				PlayMode.byId(gMusicMain.getConfigService().PS_D_PLAY_MODE),
 				gMusicMain.getConfigService().PS_D_PARTICLES,
@@ -96,6 +106,7 @@ public class PlaySettingsService {
 	public void savePlaySettings(@NotNull UUID uuid, @Nullable PlaySettings playSettings) {
 		try {
 			gMusicMain.getDataService().execute("DELETE FROM gmusic_play_settings WHERE uuid = ?", uuid.toString());
+			gMusicMain.getDataService().execute("DELETE FROM gmusic_play_settings_stereo WHERE uuid = ?", uuid.toString());
 			gMusicMain.getDataService().execute("DELETE FROM gmusic_play_settings_favorites WHERE uuid = ?", uuid.toString());
 
 			if(playSettings == null) {
@@ -116,6 +127,11 @@ public class PlaySettingsService {
 					playSettings.isToggleMode(),
 					playSettings.getRange(),
 					playSettings.getCurrentSong()
+			);
+
+			gMusicMain.getDataService().execute("INSERT INTO gmusic_play_settings_stereo (uuid, stereo) VALUES (?, ?)",
+					uuid.toString(),
+					playSettings.isStereo()
 			);
 
 			if(playSettings.getFavorites().isEmpty()) return;

--- a/core/src/main/java/dev/geco/gmusic/service/RadioService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/RadioService.java
@@ -137,7 +137,7 @@ public class RadioService {
 								PlaySettings playerPlaySettings = gMusicMain.getPlaySettingsService().getPlaySettings(player.getUniqueId());
 								float volume = playerPlaySettings.getFixedVolume() * notePart.getVolume();
 
-								Location location = notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
+								Location location = playSettings.isStereo() || notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
 
 								if (!gMusicMain.getConfigService().ENVIRONMENT_EFFECTS)
 									player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
@@ -159,7 +159,7 @@ public class RadioService {
 								if (notePart.getSound() != null) {
 									float volume = (float) ((playersInRange.get(player) - jukeBoxPlaySettings.getRange()) * jukeBoxPlaySettings.getFixedVolume() / (double) -jukeBoxPlaySettings.getRange()) * notePart.getVolume();
 
-									Location location = notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
+									Location location = gMusicMain.getConfigService().LOCATIONAL_JUKEBOX_SOUNDS ? boxLocation : playSettings.isStereo() || notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
 
 									if (!gMusicMain.getConfigService().ENVIRONMENT_EFFECTS) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
 									else {
@@ -168,7 +168,6 @@ public class RadioService {
 									}
 								} else if (notePart.getStopSound() != null) player.stopSound(notePart.getStopSound(), song.getSoundCategory());
 							}
-							players.addAll(playersInRange.keySet());
 						}
 					}
 				}

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -16,10 +16,15 @@ Options:
     # Defines whether the resource pack should be automatically downloaded and applied to the user
     force-resources: true
 
+  # Defines whether a jukebox should play music at the jukebox's location
+  locational-jukebox-sounds: true
+
   # Defines the range a player can hear the sound of a jukebox
+  # Requires locational-jukebox-sounds: false
   jukebox-range: 50
 
   # Defines the max range of a jukebox
+  # Requires locational-jukebox-sounds: false
   max-jukebox-range: 500
 
   ActionBar:
@@ -62,6 +67,7 @@ Options:
     Default:
       playlist-mode: 0
       volume: 70
+      stereo: true
       join: false
       play-mode: 0
       particles: true

--- a/resources/lang/en_us.yml
+++ b/resources/lang/en_us.yml
@@ -85,6 +85,7 @@ MusicGUI:
 
   music-options: "&cOptions"
   music-options-volume: "&aVolume:&b %Volume%%"
+  music-options-stereo: "&aStereo:&6 %Stereo%"
   music-options-join: "&aWelcome music:&6 %Join%"
   music-options-play-mode-once: "&aMode:&6 Once"
   music-options-play-mode-shuffle: "&aMode:&6 Shuffle"


### PR DESCRIPTION
- Players can toggle stereo/mono audio in music GUIs.
- Adds a config toggle for playing sounds at the jukebox location instead of directly at the player's position. If enabled, the stereo toggle is disabled, and the jukebox range is controlled by volume instead.