### PR TITLE
Custom instrument support

### DIFF
--- a/core/src/main/java/dev/geco/gmusic/model/CustomInstrument.java
+++ b/core/src/main/java/dev/geco/gmusic/model/CustomInstrument.java
@@ -1,0 +1,22 @@
+package dev.geco.gmusic.model;
+
+import org.jetbrains.annotations.NotNull;
+
+public class CustomInstrument implements Instrument {
+
+    private final String sound;
+    private final int key;
+
+    public CustomInstrument(String sound, int key) {
+        this.sound = sound;
+        this.key = key;
+    }
+
+    @Override
+    public @NotNull String getSound() { return sound; }
+    @Override
+    public int getInstrumentKey() { return key; }
+    @Override
+    public boolean isCustom() { return true; }
+
+}

--- a/core/src/main/java/dev/geco/gmusic/model/Instrument.java
+++ b/core/src/main/java/dev/geco/gmusic/model/Instrument.java
@@ -1,0 +1,11 @@
+package dev.geco.gmusic.model;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface Instrument {
+
+    @NotNull String getSound();
+    default int getInstrumentKey() { return 12; }
+    default boolean isCustom() { return false; }
+
+}

--- a/core/src/main/java/dev/geco/gmusic/model/NoteInstrument.java
+++ b/core/src/main/java/dev/geco/gmusic/model/NoteInstrument.java
@@ -3,7 +3,7 @@ package dev.geco.gmusic.model;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public enum NoteInstrument {
+public enum NoteInstrument implements Instrument {
 
 	HARP(0, "block.note_block.harp"),
 	BASS(1, "block.note_block.bass"),
@@ -34,8 +34,8 @@ public enum NoteInstrument {
 		this.sound = sound;
 	}
 
-	public static @Nullable String getIdSound(int id) {
-		for(NoteInstrument noteInstrument : values()) if(noteInstrument.id == id) return noteInstrument.sound;
+	public static @Nullable NoteInstrument fromId(int id) {
+		for(NoteInstrument noteInstrument : values()) if(noteInstrument.id == id) return noteInstrument;
 		return null;
 	}
 
@@ -43,6 +43,7 @@ public enum NoteInstrument {
 		return id;
 	}
 
+	@Override
 	public @NotNull String getSound() {
 		return sound;
 	}

--- a/core/src/main/java/dev/geco/gmusic/model/NotePart.java
+++ b/core/src/main/java/dev/geco/gmusic/model/NotePart.java
@@ -21,9 +21,19 @@ public class NotePart {
 
 		String[] parts = notePartString.split(PARTS);
 
-		if(!parts[0].startsWith(STOP)) sound = this.note.getSong().getInstruments().get(parts[0]);
-		else stopSound = this.note.getSong().getInstruments().get(parts[0].replace(STOP, ""));
-		if(sound == null || stopSound != null) return;
+		Instrument instrument;
+		if(!parts[0].startsWith(STOP)) {
+			instrument = this.note.getSong().getInstruments().get(parts[0]);
+			if(instrument == null) return;
+			sound = instrument.getSound();
+			int idx = sound.lastIndexOf('/');
+			if(idx >= 0) sound = sound.substring(idx + 1);
+		} else {
+			instrument = this.note.getSong().getInstruments().get(parts[0].replace(STOP, ""));
+			if(instrument == null) return;
+			stopSound = instrument.getSound();
+			return;
+		}
 
 		if(parts.length == 1 || parts[1].equals(VAR)) {
 			volume = 1f;
@@ -34,9 +44,9 @@ public class NotePart {
 		if(parts.length > 2 && !parts[2].equals(VAR)) {
 			if(parts[2].contains(KEYFLOAT)) {
 				int noteKey = Integer.parseInt(parts[2].replace(KEYFLOAT, ""));
-				pitch = getPitch(noteKey);
-				originalPitch = getOriginalPitch(noteKey);
-				if(GMusicMain.getInstance().getConfigService().S_EXTENDED_RANGE) {
+				pitch = getPitch(noteKey, instrument);
+				originalPitch = getOriginalPitch(noteKey, instrument);
+				if(!instrument.isCustom() && GMusicMain.getInstance().getConfigService().S_EXTENDED_RANGE) {
 					if(originalPitch >= 48) {
 						sound += "_2";
 					} else if(originalPitch >= 24) {
@@ -56,8 +66,9 @@ public class NotePart {
 		if(parts.length > 3) distance = ((Integer.parseInt(parts[3]) - 100) / 200f) * 2f;
 	}
 
-	private float getPitch(int note) {
-		if(!GMusicMain.getInstance().getConfigService().S_EXTENDED_RANGE) {
+	private float getPitch(int note, Instrument instrument) {
+		note += (instrument.getInstrumentKey() - 12);
+		if(instrument.isCustom() || !GMusicMain.getInstance().getConfigService().S_EXTENDED_RANGE) {
 			if(note < 0) return 0.5f;
 			if(note > 24) return 2f;
 			return (float) Math.pow(2, ((float) (note - 12) / 12));
@@ -78,8 +89,9 @@ public class NotePart {
 		return (float) Math.pow(2, ((float) (note - 12) / 12));
 	}
 
-	private int getOriginalPitch(int note) {
-		if(!GMusicMain.getInstance().getConfigService().S_EXTENDED_RANGE) {
+	private int getOriginalPitch(int note, Instrument instrument) {
+		note += (instrument.getInstrumentKey() - 12);
+		if(instrument.isCustom() || !GMusicMain.getInstance().getConfigService().S_EXTENDED_RANGE) {
 			if(note < 0) return 0;
 			return Math.min(note, 24);
 		}

--- a/core/src/main/java/dev/geco/gmusic/model/Song.java
+++ b/core/src/main/java/dev/geco/gmusic/model/Song.java
@@ -21,15 +21,15 @@ public class Song {
 	private final List<String> description;
 	private Material discMaterial;
 	private SoundCategory soundCategory;
-	private final HashMap<String, String> instruments = new HashMap<>();
+	private final HashMap<String, Instrument> instruments = new HashMap<>();
 	private final HashMap<String, List<Note>> parts = new HashMap<>();
 	private final List<Note> notes = new ArrayList<>();
 	private final HashMap<Long, List<NotePart>> content = new HashMap<>();
 	private long noteAmount = 0;
 	private long length = 0;
 
-    public Song(File gnbsFile) {
-        YamlConfiguration config = YamlConfiguration.loadConfiguration(gnbsFile);
+	public Song(File gnbsFile) {
+		YamlConfiguration config = YamlConfiguration.loadConfiguration(gnbsFile);
 		filename = gnbsFile.getName();
 
 		id = config.getString("Song.Id");
@@ -48,14 +48,18 @@ public class Song {
 		try { songInstruments.addAll(config.getConfigurationSection("Song.Content.Instruments").getKeys(false)); } catch(Throwable ignored) { }
 		for(String songInstrument : songInstruments) {
 			try {
-				String noteInstrument = NoteInstrument.getIdSound(Integer.parseInt(config.getString("Song.Content.Instruments." + songInstrument, "-1")));
+				NoteInstrument noteInstrument = NoteInstrument.fromId(Integer.parseInt(config.getString("Song.Content.Instruments." + songInstrument, "-1")));
 				if(noteInstrument != null) instruments.put(songInstrument, noteInstrument);
 				else throw new IllegalArgumentException();
-			} catch(IllegalArgumentException e) { instruments.put(songInstrument, config.getString("Song.Content.Instruments." + songInstrument)); }
+			} catch(IllegalArgumentException e) {
+				String sound = config.getString("Song.Content.Instruments." + songInstrument);
+				int key = config.getInt("Song.Content.InstrumentKeys." + songInstrument, 12);
+				instruments.put(songInstrument, new CustomInstrument(sound, key));
+			}
 		}
 		for(NoteInstrument inst : NoteInstrument.values()) {
 			if(instruments.containsKey("" + inst.getId())) continue;
-			instruments.put("" + inst.getId(), inst.getSound());
+			instruments.put("" + inst.getId(), inst);
 		}
 
 		List<String> songParts = new ArrayList<>();
@@ -122,7 +126,7 @@ public class Song {
 
 	public SoundCategory getSoundCategory() { return soundCategory; }
 
-	public HashMap<String, String> getInstruments() { return instruments; }
+	public HashMap<String, Instrument> getInstruments() { return instruments; }
 
 	public HashMap<String, List<Note>> getParts() { return parts; }
 

--- a/core/src/main/java/dev/geco/gmusic/service/converter/NBSConverter.java
+++ b/core/src/main/java/dev/geco/gmusic/service/converter/NBSConverter.java
@@ -1,6 +1,7 @@
 package dev.geco.gmusic.service.converter;
 
 import dev.geco.gmusic.GMusicMain;
+import dev.geco.gmusic.model.CustomInstrument;
 import dev.geco.gmusic.model.NoteInstrument;
 import dev.geco.gmusic.service.SongService;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -28,10 +29,11 @@ public class NBSConverter {
 
 			short type = readShort(dataInput);
 			int version = 0;
+			byte defaultInstruments = 10;
 
 			if(type == 0) {
 				version = dataInput.readByte();
-				dataInput.readByte();
+				defaultInstruments = dataInput.readByte();
 				if(version >= 3) readShort(dataInput);
 			}
 
@@ -127,12 +129,13 @@ public class NBSConverter {
 
 			byte midiInstrumentsLength = dataInput.readByte();
 
-			List<String> midiInstruments = new ArrayList<>();
+			List<CustomInstrument> midiInstruments = new ArrayList<>();
 
 			for(int instrumentCount = 0; instrumentCount < midiInstrumentsLength; instrumentCount++) {
 				readString(dataInput);
-				midiInstruments.add(readString(dataInput).replace(".ogg", ""));
-				dataInput.readByte();
+				String sound = readString(dataInput).replace(".ogg", "");
+				byte key = dataInput.readByte();
+				midiInstruments.add(new CustomInstrument(sound, ((int) key) - 33));
 				dataInput.readByte();
 			}
 
@@ -144,16 +147,26 @@ public class NBSConverter {
 
 			YamlConfiguration gnbsStruct = YamlConfiguration.loadConfiguration(gnbsFile);
 
-			gnbsStruct.set("Song.Id", title.replace(" ", ""));
+			String id = title.replace(" ", "");
+			gnbsStruct.set("Song.Id", id);
 			gnbsStruct.set("Song.Title", title);
 			gnbsStruct.set("Song.OriginalAuthor", originalAuthor);
 			gnbsStruct.set("Song.Author", author);
 			gnbsStruct.set("Song.Description", description.replace(" ", "").isEmpty() ? new ArrayList<>() : Arrays.asList(description.split("\n")));
 			gnbsStruct.set("Song.Category", "RECORDS");
 
-			for(NoteInstrument inst : NoteInstrument.values()) if(gnbsInstruments.contains(inst.getId())) gnbsStruct.set("Song.Content.Instruments." + inst.getId(), inst.getId());
+			for(NoteInstrument inst : NoteInstrument.values()) if(inst.getId() < defaultInstruments && gnbsInstruments.contains(inst.getId())) gnbsStruct.set("Song.Content.Instruments." + inst.getId(), inst.getId());
 
-			for(int instrument = NoteInstrument.values().length; instrument < NoteInstrument.values().length + midiInstruments.size(); instrument++) gnbsStruct.set("Song.Content.Instruments." + instrument, midiInstruments.get(instrument - NoteInstrument.values().length));
+			for(int instrument = defaultInstruments; instrument < defaultInstruments + midiInstruments.size(); instrument++) {
+				CustomInstrument customInstrument = midiInstruments.get(instrument - defaultInstruments);
+				String sound = customInstrument.getSound();
+				gnbsStruct.set("Song.Content.Instruments." + instrument, sound);
+				gnbsStruct.set("Song.Content.InstrumentKeys." + instrument, customInstrument.getInstrumentKey());
+				String trimmedSound = sound;
+				int idx = trimmedSound.lastIndexOf('/');
+				if(idx >= 0) trimmedSound = trimmedSound.substring(idx + 1);
+				if(!trimmedSound.contains(".")) gMusicMain.getLogger().warning("Possibly unknown custom instrument " + sound + " in song " + id);
+			}
 
 			gnbsStruct.set("Song.Content.Main", gnbsContent);
 			gnbsStruct.save(gnbsFile);


### PR DESCRIPTION
Adds proper support for custom instruments, as long as they are playable Minecraft sounds:

- The sound name must be a playable sound ID such as `entity.experience_orb.pickup`, possibly stored in a folder such as `custom/entity.experience_orb.pickup`.
- Some NBS songs (such as songs downloaded from noteblock.world) have custom instruments that are separate sound files such as `minecraft/dig/sand1` instead of playable sound IDs. The plugin does not know what sound to play, so it will print a warning message in console for these instruments when converting to the `.gnbs` format.
- Sounds in non-`minecraft` namespaces are not yet supported.
- Custom instruments can have a base key (default F#4, 45 in `.nbs`, 12 in `.gbns`) which affects all notes played with that instrument.
- Fixed a bug where `.nbs` songs with custom instruments would sometimes convert those custom instruments to regular instruments, often trumpets.

Any songs with custom instruments in non-default keys and any songs affected by the wrong instrument bug will need to be re-converted to fix. Otherwise, these changes are backwards compatible.

See [Megalovania](https://github.com/OpenNBS/NoteBlockStudio/blob/main/datafiles/Songs/Megalovania%20-%20Super%20Smash%20Bros.%20Ultimate.nbs) (included with Note Block Studio) for an example of a song that uses custom instruments. Current versions play trumpets instead, but this PR correctly plays custom instruments.