### PR TITLE
Migrate play settings to 2.4.0 format

### DIFF
--- a/core/src/main/java/dev/geco/gmusic/service/PlaySettingsService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/PlaySettingsService.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,7 +31,76 @@ public class PlaySettingsService {
 		try {
 			gMusicMain.getDataService().execute("CREATE TABLE IF NOT EXISTS gmusic_play_setting (uuid CHAR(36) PRIMARY KEY, play_type INTEGER, play_list_mode INTEGER, volume INTEGER, play_mode INTEGER, show_particles INTEGER, reverse_mode INTEGER, toggle_mode INTEGER, range INTEGER);");
 			gMusicMain.getDataService().execute("CREATE TABLE IF NOT EXISTS gmusic_play_setting_favorite (uuid CHAR(36), song_id TEXT, FOREIGN KEY (uuid) REFERENCES gmusic_play_setting(uuid) ON DELETE CASCADE ON UPDATE CASCADE);");
+			migrateTo_2_4_0();
 		} catch(Throwable e) { gMusicMain.getLogger().log(Level.SEVERE, "Could not create play settings database tables!", e); }
+	}
+
+	private void migrateTo_2_4_0() throws SQLException {
+		if(tableExists("gmusic_play_settings")) {
+			try(ResultSet oldSettings = gMusicMain.getDataService().executeAndGet("SELECT uuid, playListMode, volume, playMode, showParticles, reverseMode, toggleMode, range FROM gmusic_play_settings")) {
+				while(oldSettings.next()) {
+					String uuid = oldSettings.getString("uuid");
+					try(ResultSet rs = gMusicMain.getDataService().executeAndGet("SELECT 1 FROM gmusic_play_setting WHERE uuid = ? LIMIT 1", uuid)) {
+						if(rs.next()) continue;
+					}
+					gMusicMain.getDataService().execute(
+							"INSERT INTO gmusic_play_setting (uuid, play_type, play_list_mode, volume, play_mode, show_particles, reverse_mode, toggle_mode, range) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+							uuid,
+							PlayType.DEFAULT.getId(),
+							oldSettings.getInt("playListMode"),
+							oldSettings.getInt("volume"),
+							oldSettings.getInt("playMode"),
+							oldSettings.getInt("showParticles"),
+							oldSettings.getInt("reverseMode"),
+							oldSettings.getInt("toggleMode"),
+							oldSettings.getLong("range")
+					);
+				}
+			}
+		}
+
+		if(tableExists("gmusic_play_settings_favorites")) {
+			Map<String, List<String>> favoritesByUuid = new HashMap<>();
+			try(ResultSet oldFavorites = gMusicMain.getDataService().executeAndGet("SELECT uuid, songId FROM gmusic_play_settings_favorites")) {
+				while(oldFavorites.next()) {
+					String uuid = oldFavorites.getString("uuid");
+					String songId = oldFavorites.getString("songId");
+
+					favoritesByUuid.computeIfAbsent(uuid, k -> new ArrayList<>()).add(songId);
+				}
+			}
+
+			for(Map.Entry<String, List<String>> entry : favoritesByUuid.entrySet()) {
+				String uuid = entry.getKey();
+				List<String> songIds = entry.getValue();
+
+				boolean uuidExistsInNewSettings;
+				try(ResultSet rs = gMusicMain.getDataService().executeAndGet("SELECT 1 FROM gmusic_play_setting WHERE uuid = ? LIMIT 1", uuid)) {
+					uuidExistsInNewSettings = rs.next();
+				}
+
+				// Only migrate favorites if UUID does NOT exist in new settings table
+				if(!uuidExistsInNewSettings) {
+					for(String songId : songIds) {
+						gMusicMain.getDataService().execute(
+								"INSERT INTO gmusic_play_setting_favorite (uuid, song_id) VALUES (?, ?)",
+								uuid,
+								songId
+						);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * @param tableName Unsafe for user input! Must be a <strong>constant</strong> table name
+	 * @return if the table exists
+	 */
+	private boolean tableExists(String tableName) {
+		try(ResultSet rs = gMusicMain.getDataService().executeAndGet("SELECT 1 FROM " + tableName + " LIMIT 1")) {
+			return rs.next();
+		} catch(Throwable ignored) { return false; }
 	}
 
 	public void loadPlaySettings() {

--- a/core/src/main/java/dev/geco/gmusic/service/PlaySettingsService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/PlaySettingsService.java
@@ -57,6 +57,8 @@ public class PlaySettingsService {
 					);
 				}
 			}
+
+			gMusicMain.getDataService().execute("DROP TABLE gmusic_play_settings");
 		}
 
 		if(tableExists("gmusic_play_settings_favorites")) {
@@ -79,7 +81,6 @@ public class PlaySettingsService {
 					uuidExistsInNewSettings = rs.next();
 				}
 
-				// Only migrate favorites if UUID does NOT exist in new settings table
 				if(!uuidExistsInNewSettings) {
 					for(String songId : songIds) {
 						gMusicMain.getDataService().execute(
@@ -90,6 +91,8 @@ public class PlaySettingsService {
 					}
 				}
 			}
+
+			gMusicMain.getDataService().execute("DROP TABLE gmusic_play_settings_favorites");
 		}
 	}
 


### PR DESCRIPTION
Commit 3c8b134 changed the play setting table names from `gmusic_play_settings` and `gmusic_play_settings_favorites` to `gmusic_play_setting` and `gmusic_play_setting_favorites`. Since the plugin does not migrate data from the old tables, all play settings are lost when upgrading to 2.4.0. Since the default range is 0 (jukeboxes only set their range to 50 when placed), existing jukeboxes will no longer play music unless the range is reset.

This PR migrates all play settings from the old format to the 2.4.0 format. All existing players and jukeboxes will have their settings restored unless their settings were changed after the 2.4.0 update. All existing players will have their favorites restored unless they added a favorite after the 2.4.0 update.