### PR TITLE
Fix various issues with sound movement and attenuation

### DIFF
--- a/core/src/main/java/dev/geco/gmusic/GMusicMain.java
+++ b/core/src/main/java/dev/geco/gmusic/GMusicMain.java
@@ -35,6 +35,7 @@ import dev.geco.gmusic.service.converter.WavConverter;
 import dev.geco.gmusic.service.message.PaperMessageService;
 import dev.geco.gmusic.service.message.SpigotMessageService;
 import dev.geco.gmusic.util.EnvironmentUtil;
+import dev.geco.gmusic.util.MusicUtil;
 import dev.geco.gmusic.util.SteroNoteUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -68,6 +69,7 @@ public class GMusicMain extends JavaPlugin {
     private WavConverter wavConverter;
     private EnvironmentUtil environmentUtil;
     private SteroNoteUtil steroNoteUtil;
+    private MusicUtil musicUtil;
     private GriefPreventionLink griefPreventionLink;
     private PlaceholderAPILink placeholderAPILink;
     private PlotSquaredLink plotSquaredLink;
@@ -115,6 +117,8 @@ public class GMusicMain extends JavaPlugin {
 
     public SteroNoteUtil getSteroNoteUtil() { return steroNoteUtil; }
 
+    public MusicUtil getMusicUtil() { return musicUtil; }
+
     public GriefPreventionLink getGriefPreventionLink() { return griefPreventionLink; }
 
     public PlaceholderAPILink getPlaceholderAPILink() { return placeholderAPILink; }
@@ -152,6 +156,7 @@ public class GMusicMain extends JavaPlugin {
 
         environmentUtil = new EnvironmentUtil(this);
         steroNoteUtil = new SteroNoteUtil();
+        musicUtil = new MusicUtil(this);
 
         loadFeatures();
 

--- a/core/src/main/java/dev/geco/gmusic/model/PlaySettings.java
+++ b/core/src/main/java/dev/geco/gmusic/model/PlaySettings.java
@@ -16,6 +16,7 @@ public class PlaySettings {
 	private boolean reverseMode;
 	private boolean toggleMode;
 	private long range;
+	private boolean stereo;
 	private @NotNull List<Song> favorites;
 
 	public PlaySettings(
@@ -28,6 +29,7 @@ public class PlaySettings {
 			boolean reverseMode,
 			boolean toggleMode,
 			long range,
+			boolean stereo,
 			@NotNull List<Song> favorites
 	) {
 		this.uuid = uuid;
@@ -39,6 +41,7 @@ public class PlaySettings {
 		this.reverseMode = reverseMode;
 		this.toggleMode = toggleMode;
 		this.range = range;
+		this.stereo = stereo;
 		this.favorites = favorites;
 	}
 
@@ -75,6 +78,10 @@ public class PlaySettings {
 	public long getRange() { return range; }
 
 	public void setRange(long range) { this.range = range; }
+
+	public boolean isStereo() { return stereo; }
+
+	public void setStereo(boolean stereo) { this.stereo = stereo; }
 
 	public @NotNull List<Song> getFavorites() { return favorites; }
 

--- a/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
+++ b/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
@@ -189,8 +189,6 @@ public class MusicGUI {
 			if(searchKey != null && !searchKey.isEmpty()) filteredSongs = gMusicMain.getSongService().filterSongsBySearch(songs, searchKey);
 		}
 
-		List<Button> buttonsToAdd = new ArrayList<>();
-
 		if(!gMusicMain.getConfigService().G_DISABLE_RANDOM_SONG && playSettings.getPlayListMode() != PlayListMode.RADIO && !filteredSongs.isEmpty()) {
 			item = makeItem(Material.ENDER_PEARL, gMusicMain.getMessageService().getMessage("MusicGUI.music-random"));
 			Button button = new Button(item, (itemMeta, click, clicker) -> {
@@ -208,7 +206,7 @@ public class MusicGUI {
 					}
 				}
 			});
-			buttonsToAdd.add(button);
+			setButton(48, button);
 		}
 
 		if(!gMusicMain.getConfigService().G_DISABLE_PLAYLIST && playType != PlayType.RADIO) {
@@ -244,7 +242,7 @@ public class MusicGUI {
 				}
 				setDefaultBar();
 			});
-			buttonsToAdd.add(button);
+			setButton(49, button);
 		}
 
 		if(!gMusicMain.getConfigService().G_DISABLE_OPTIONS) {
@@ -252,7 +250,7 @@ public class MusicGUI {
 			Button button = new Button(item, (itemMeta, click, clicker) -> {
 				setOptionsBar();
 			});
-			buttonsToAdd.add(button);
+			setButton(50, button);
 		}
 
 		if(!gMusicMain.getConfigService().G_DISABLE_SEARCH && playSettings.getPlayListMode() != PlayListMode.RADIO && !songs.isEmpty() && gMusicMain.getVersionService().isAvailable()) {
@@ -277,14 +275,7 @@ public class MusicGUI {
 					setDefaultBar();
 				}
 			});
-			buttonsToAdd.add(button);
-		}
-
-		for(int i = 0; i < buttonsToAdd.size(); i++) {
-			int slot = 48 + i;
-			if(slot >= 52) break;
-			Button button = buttonsToAdd.get(i);
-			setButton(slot, button);
+			setButton(51, button);
 		}
 
 		setPauseResumeBar();

--- a/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
+++ b/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
@@ -233,7 +233,6 @@ public class MusicGUI {
 							setOptionsBar();
 						} else {
 							if(playType != PlayType.JUKEBOX) return;
-							if(gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS) return;
 							long range = playSettings.getRange();
 							long step = click == ClickType.SHIFT_LEFT || click == ClickType.SHIFT_RIGHT ? SHIFT_RANGE_STEPS : RANGE_STEPS;
 							long newRange = click == ClickType.MIDDLE ? gMusicMain.getConfigService().J_RANGE : (click == ClickType.RIGHT ? Math.max(range - step, 0) : Math.min(range + step, gMusicMain.getConfigService().J_MAX_RANGE));
@@ -462,7 +461,7 @@ public class MusicGUI {
 			inventory.setItem(49, itemStack);
 		}
 
-		if(playType == PlayType.JUKEBOX && !gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS) {
+		if(playType == PlayType.JUKEBOX) {
 			itemStack = new ItemStack(Material.REDSTONE);
 			itemMeta = itemStack.getItemMeta();
 			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-range", "%Range%", "" + playSettings.getRange()));

--- a/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
+++ b/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
@@ -385,7 +385,7 @@ public class MusicGUI {
 			button = new Button(item, (itemMeta, click, clicker) -> {
                 int volumn = playSettings.getVolume();
                 int step = click == ClickType.SHIFT_LEFT || click == ClickType.SHIFT_RIGHT ? SHIFT_VOLUME_STEPS : VOLUME_STEPS;
-                int newVolumn = click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_VOLUME : (click == ClickType.RIGHT ? Math.max(volumn - step, 0) : Math.min(volumn + step, 100));
+				int newVolumn = click == ClickType.MIDDLE ? (playType == PlayType.JUKEBOX ? gMusicMain.getConfigService().J_VOLUME : gMusicMain.getConfigService().PS_D_VOLUME) : (click == ClickType.RIGHT ? Math.max(volumn - step, 0) : Math.min(volumn + step, 100));
                 playSettings.setVolume(newVolumn);
                 itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-volume", "%Volume%", "" + newVolumn));
             });

--- a/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
+++ b/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
@@ -265,6 +265,9 @@ public class MusicGUI {
 								setPage(1);
 								setDefaultBar();
 							}
+						} else if(!(playType == PlayType.JUKEBOX && gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS)) {
+							playSettings.setStereo(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_STEREO : !playSettings.isStereo());
+							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-stereo", "%Stereo%", gMusicMain.getMessageService().getMessage(playSettings.isStereo() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
 						}
 					}
 					case 52 -> setPage(page - 1);
@@ -467,6 +470,14 @@ public class MusicGUI {
 			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-range", "%Range%", "" + playSettings.getRange()));
 			itemStack.setItemMeta(itemMeta);
 			inventory.setItem(50, itemStack);
+		}
+
+		if(!(playType == PlayType.JUKEBOX && gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS)) {
+			itemStack = new ItemStack(Material.EMERALD);
+			itemMeta = itemStack.getItemMeta();
+			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-stereo", "%Stereo%", gMusicMain.getMessageService().getMessage(playSettings.isStereo() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+			itemStack.setItemMeta(itemMeta);
+			inventory.setItem(51, itemStack);
 		}
 	}
 

--- a/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
+++ b/core/src/main/java/dev/geco/gmusic/model/gui/MusicGUI.java
@@ -31,11 +31,7 @@ import org.bukkit.util.ChatPaginator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.logging.Level;
 
 public class MusicGUI {
@@ -57,6 +53,7 @@ public class MusicGUI {
 	private boolean searchMode = false;
 	private String searchKey = null;
 	private final PlaySettings playSettings;
+	private final Map<Integer, ClickHandler> buttons = new HashMap<>();
 
 	public MusicGUI(@NotNull UUID uuid, @NotNull PlayType playType) {
 		this.uuid = uuid;
@@ -98,203 +95,38 @@ public class MusicGUI {
 				ItemMeta itemMeta = itemStack.getItemMeta();
 				HumanEntity clicker = event.getWhoClicked();
 				int slot = event.getRawSlot();
-				switch(slot) {
-					case 45 -> {
-						if(!optionState) {
-							PlayState songSettings = gMusicMain.getPlayService().getPlayState(uuid);
-							if(songSettings == null) return;
-							switch(playType) {
-								case DEFAULT -> {
-									Player target = Bukkit.getPlayer(uuid);
-									if(target == null) return;
-									if(songSettings.isPaused()) gMusicMain.getPlayService().resumeSong(target);
-									else gMusicMain.getPlayService().pauseSong(target);
-								}
-								case JUKEBOX -> {
-									if(songSettings.isPaused()) gMusicMain.getJukeBoxService().resumeBoxSong(uuid);
-									else gMusicMain.getJukeBoxService().pauseBoxSong(uuid);
-								}
-								case RADIO -> {
-									if(songSettings.isPaused()) gMusicMain.getRadioService().resumeSong();
-									else gMusicMain.getRadioService().pauseSong();
-								}
-							}
-						} else {
-							setDefaultBar();
-						}
+				if(slot < 0) {
+					return;
+				} else if(slot < 45) {
+					Song song = pageSongs.get(slot);
+					if(song == null) return;
+					if(click == ClickType.MIDDLE) {
+						if(playSettings.getFavorites().contains(song)) playSettings.getFavorites().remove(song);
+						else playSettings.getFavorites().add(song);
+						setPage(page);
+						return;
 					}
-					case 46 -> {
-						if(!optionState) {
-							switch(playType) {
-								case DEFAULT -> {
-									Player target = Bukkit.getPlayer(uuid);
-									if(target == null) return;
-									gMusicMain.getPlayService().stopSong(target);
-								}
-								case JUKEBOX -> {
-									gMusicMain.getJukeBoxService().stopBoxSong(uuid);
-								}
-								case RADIO -> {
-									gMusicMain.getRadioService().stopSong();
-								}
-							}
-						} else if(playType != PlayType.RADIO) {
-							int volumn = playSettings.getVolume();
-							int step = click == ClickType.SHIFT_LEFT || click == ClickType.SHIFT_RIGHT ? SHIFT_VOLUME_STEPS : VOLUME_STEPS;
-							int newVolumn = click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_VOLUME : (click == ClickType.RIGHT ? Math.max(volumn - step, 0) : Math.min(volumn + step, 100));
-							playSettings.setVolume(newVolumn);
-							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-volume", "%Volume%", "" + newVolumn));
+					switch(playType) {
+						case DEFAULT -> {
+							Player target = Bukkit.getPlayer(uuid);
+							if(target == null) return;
+							gMusicMain.getPlayService().playSong(target, song);
 						}
+						case JUKEBOX -> gMusicMain.getJukeBoxService().playBoxSong(uuid, song);
+						case RADIO -> gMusicMain.getRadioService().playSong(song);
 					}
-					case 47 -> {
-						if(!optionState) {
-							switch(playType) {
-								case DEFAULT -> {
-									Player target = Bukkit.getPlayer(uuid);
-									if(target == null) return;
-									gMusicMain.getPlayService().playSong(target, gMusicMain.getPlayService().getNextSong(target));
-								}
-								case JUKEBOX -> {
-									gMusicMain.getJukeBoxService().playBoxSong(uuid, gMusicMain.getJukeBoxService().getNextSong(uuid));
-								}
-								case RADIO -> {
-									gMusicMain.getRadioService().playSong(gMusicMain.getRadioService().getNextSong());
-								}
-							}
-						} else if(playType != PlayType.RADIO) {
-							playSettings.setShowParticles(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_PARTICLES : !playSettings.isShowingParticles());
-							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-particle", "%Particle%", gMusicMain.getMessageService().getMessage(playSettings.isShowingParticles() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
-						}
-					}
-					case 48 -> {
-						if(playSettings.getPlayListMode() == PlayListMode.RADIO) return;
-						if(!optionState) {
-							if(gMusicMain.getConfigService().G_DISABLE_RANDOM_SONG) return;
-							switch(playType) {
-								case DEFAULT -> {
-									Player target = Bukkit.getPlayer(uuid);
-									if(target == null) return;
-									gMusicMain.getPlayService().playSong(target, gMusicMain.getPlayService().getRandomSong(uuid, playType));
-								}
-								case JUKEBOX -> {
-									gMusicMain.getJukeBoxService().playBoxSong(uuid, gMusicMain.getPlayService().getRandomSong(uuid, playType));
-								}
-								case RADIO -> {
-									gMusicMain.getRadioService().playSong(gMusicMain.getPlayService().getRandomSong(uuid, playType));
-								}
-							}
-						} else {
-							int playModeId = playSettings.getPlayMode().getId();
-							PlayMode playMode = PlayMode.byId(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_PLAY_MODE : (click == ClickType.RIGHT ? (playModeId - 1 < 0 ? PlayMode.values().length - 1 : playModeId - 1) : (playModeId + 1 > PlayMode.values().length - 1 ? 0 : playModeId + 1)));
-							playSettings.setPlayMode(playMode);
-							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage(playMode == PlayMode.DEFAULT ? "MusicGUI.music-options-play-mode-once" : playMode == PlayMode.SHUFFLE ? "MusicGUI.music-options-play-mode-shuffle" : "MusicGUI.music-options-play-mode-repeat"));
-						}
-					}
-					case 49 -> {
-						if(!optionState) {
-							if(playType == PlayType.RADIO) return;
-							int playListModeId = playSettings.getPlayListMode().getId();
-							PlayListMode playListMode = PlayListMode.byId(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_PLAYLIST_MODE : (click == ClickType.RIGHT ? (playListModeId - 1 < 0 ? PlayListMode.values().length - 1 : playListModeId - 1) : (playListModeId + 1 > PlayListMode.values().length - 1 ? 0 : playListModeId + 1)));
-							playSettings.setPlayListMode(playListMode);
-							switch(playType) {
-								case DEFAULT -> {
-									Player target = Bukkit.getPlayer(uuid);
-									if(playListMode.getId() != playListModeId && target != null) {
-										setPage(1);
-										gMusicMain.getPlayService().stopSong(target);
-									}
-									if(playListMode == PlayListMode.RADIO) {
-										gMusicMain.getRadioService().addRadioPlayer(target);
-									} else {
-										gMusicMain.getRadioService().removeRadioPlayer(target);
-									}
-								}
-								case JUKEBOX -> {
-									if(playListMode.getId() != playListModeId) {
-										setPage(1);
-										gMusicMain.getJukeBoxService().stopBoxSong(uuid);
-									}
-									if(playListMode == PlayListMode.RADIO) {
-										gMusicMain.getRadioService().addRadioJukeBox(uuid, gMusicMain.getJukeBoxService().getJukeBoxBlock(uuid));
-									} else {
-										gMusicMain.getRadioService().removeRadioJukeBox(uuid);
-									}
-								}
-							}
-							setDefaultBar();
-						} else {
-							if(playSettings.getPlayListMode() == PlayListMode.RADIO) return;
-							playSettings.setReverseMode(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_REVERSE : !playSettings.isReverseMode());
-							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-reverse", "%Reverse%", gMusicMain.getMessageService().getMessage(playSettings.isReverseMode() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
-						}
-					}
-					case 50 -> {
-						if(!optionState) {
-							setOptionsBar();
-						} else {
-							if(playType != PlayType.JUKEBOX) return;
-							long range = playSettings.getRange();
-							long step = click == ClickType.SHIFT_LEFT || click == ClickType.SHIFT_RIGHT ? SHIFT_RANGE_STEPS : RANGE_STEPS;
-							long newRange = click == ClickType.MIDDLE ? gMusicMain.getConfigService().J_RANGE : (click == ClickType.RIGHT ? Math.max(range - step, 0) : Math.min(range + step, gMusicMain.getConfigService().J_MAX_RANGE));
-							playSettings.setRange(newRange);
-							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-range", "%Range%", "" + newRange));
-						}
-					}
-					case 51 -> {
-						if(!optionState) {
-							if(playSettings.getPlayListMode() == PlayListMode.RADIO) return;
-							if(!gMusicMain.getVersionService().isAvailable()) return;
-							if(click == ClickType.LEFT) {
-								MusicInputGUI inputGUI = getInputGUIInstance((input) -> {
-									searchKey = input;
-									setPage(1);
-									setDefaultBar();
-									clicker.openInventory(inventory);
-									searchMode = false;
-									return true;
-								}, ItemMeta::getDisplayName);
-								ItemStack nameItem = new ItemStack(Material.NAME_TAG);
-								ItemMeta nameItemMeta = nameItem.getItemMeta();
-								nameItemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-search-menu-field"));
-								nameItem.setItemMeta(nameItemMeta);
-								searchKey = null;
-								searchMode = true;
-								inputGUI.open(clicker, gMusicMain.getMessageService().getMessage("MusicGUI.music-search-menu-title"), nameItem);
-							} else if(searchKey != null) {
-								searchKey = null;
-								setPage(1);
-								setDefaultBar();
-							}
-						} else if(!(playType == PlayType.JUKEBOX && gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS)) {
-							playSettings.setStereo(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_STEREO : !playSettings.isStereo());
-							itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-stereo", "%Stereo%", gMusicMain.getMessageService().getMessage(playSettings.isStereo() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
-						}
-					}
-					case 52 -> setPage(page - 1);
-					case 53 -> setPage(page + 1);
-					default -> {
-						if(slot < 0 || slot > 44) return;
-						Song song = pageSongs.get(slot);
-						if(song == null) return;
-						if(click == ClickType.MIDDLE) {
-							if(playSettings.getFavorites().contains(song)) playSettings.getFavorites().remove(song);
-							else playSettings.getFavorites().add(song);
-							setPage(page);
-							return;
-						}
-						switch(playType) {
-							case DEFAULT -> {
-								Player target = Bukkit.getPlayer(uuid);
-								if(target == null) return;
-								gMusicMain.getPlayService().playSong(target, song);
-							}
-							case JUKEBOX -> gMusicMain.getJukeBoxService().playBoxSong(uuid, song);
-							case RADIO -> gMusicMain.getRadioService().playSong(song);
-						}
-					}
+					setPauseResumeBar();
+				} else if(slot < 52) {
+					ClickHandler handler = buttons.get(slot);
+					if(handler != null) handler.onClick(itemMeta, click, clicker);
+					itemStack.setItemMeta(itemMeta);
+				} else if(slot == 52) {
+					setPage(page - 1);
+					setPauseResumeBar();
+				} else if(slot == 53) {
+					setPage(page + 1);
+					setPauseResumeBar();
 				}
-				setPauseResumeBar();
-				itemStack.setItemMeta(itemMeta);
 			}
 
 			@EventHandler (ignoreCancelled = true, priority = EventPriority.LOWEST)
@@ -337,15 +169,16 @@ public class MusicGUI {
 		return null;
 	}
 
-	private void clearBar() { for(int slot = 45; slot < 52; slot++) inventory.setItem(slot, null); }
+	private void clearBar() {
+		for(int slot = 45; slot < 52; slot++) setButton(slot, null);
+	}
 
 	public void setDefaultBar() {
 		optionState = false;
 
 		clearBar();
 
-		ItemStack itemStack;
-		ItemMeta itemMeta;
+		ItemStack item;
 
 		List<Song> songs = new ArrayList<>();
 		List<Song> filteredSongs = songs;
@@ -356,36 +189,102 @@ public class MusicGUI {
 			if(searchKey != null && !searchKey.isEmpty()) filteredSongs = gMusicMain.getSongService().filterSongsBySearch(songs, searchKey);
 		}
 
+		List<Button> buttonsToAdd = new ArrayList<>();
+
 		if(!gMusicMain.getConfigService().G_DISABLE_RANDOM_SONG && playSettings.getPlayListMode() != PlayListMode.RADIO && !filteredSongs.isEmpty()) {
-			itemStack = new ItemStack(Material.ENDER_PEARL);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-random"));
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(48, itemStack);
+			item = makeItem(Material.ENDER_PEARL, gMusicMain.getMessageService().getMessage("MusicGUI.music-random"));
+			Button button = new Button(item, (itemMeta, click, clicker) -> {
+				switch(playType) {
+					case DEFAULT -> {
+						Player target = Bukkit.getPlayer(uuid);
+						if(target == null) return;
+						gMusicMain.getPlayService().playSong(target, gMusicMain.getPlayService().getRandomSong(uuid, playType));
+					}
+					case JUKEBOX -> {
+						gMusicMain.getJukeBoxService().playBoxSong(uuid, gMusicMain.getPlayService().getRandomSong(uuid, playType));
+					}
+					case RADIO -> {
+						gMusicMain.getRadioService().playSong(gMusicMain.getPlayService().getRandomSong(uuid, playType));
+					}
+				}
+			});
+			buttonsToAdd.add(button);
 		}
 
 		if(!gMusicMain.getConfigService().G_DISABLE_PLAYLIST && playType != PlayType.RADIO) {
-			itemStack = new ItemStack(Material.NOTE_BLOCK);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage(playSettings.getPlayListMode() == PlayListMode.DEFAULT ? "MusicGUI.music-playlist-mode-default" : playSettings.getPlayListMode() == PlayListMode.FAVORITES ? "MusicGUI.music-playlist-mode-favorites" : "MusicGUI.music-playlist-mode-radio"));
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(49, itemStack);
+			item = makeItem(Material.NOTE_BLOCK, gMusicMain.getMessageService().getMessage(playSettings.getPlayListMode() == PlayListMode.DEFAULT ? "MusicGUI.music-playlist-mode-default" : playSettings.getPlayListMode() == PlayListMode.FAVORITES ? "MusicGUI.music-playlist-mode-favorites" : "MusicGUI.music-playlist-mode-radio"));
+			Button button = new Button(item, (itemMeta, click, clicker) -> {
+				int playListModeId = playSettings.getPlayListMode().getId();
+				PlayListMode playListMode = PlayListMode.byId(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_PLAYLIST_MODE : (click == ClickType.RIGHT ? (playListModeId - 1 < 0 ? PlayListMode.values().length - 1 : playListModeId - 1) : (playListModeId + 1 > PlayListMode.values().length - 1 ? 0 : playListModeId + 1)));
+				playSettings.setPlayListMode(playListMode);
+				switch(playType) {
+					case DEFAULT -> {
+						Player target = Bukkit.getPlayer(uuid);
+						if(playListMode.getId() != playListModeId && target != null) {
+							setPage(1);
+							gMusicMain.getPlayService().stopSong(target);
+						}
+						if(playListMode == PlayListMode.RADIO) {
+							gMusicMain.getRadioService().addRadioPlayer(target);
+						} else {
+							gMusicMain.getRadioService().removeRadioPlayer(target);
+						}
+					}
+					case JUKEBOX -> {
+						if(playListMode.getId() != playListModeId) {
+							setPage(1);
+							gMusicMain.getJukeBoxService().stopBoxSong(uuid);
+						}
+						if(playListMode == PlayListMode.RADIO) {
+							gMusicMain.getRadioService().addRadioJukeBox(uuid, gMusicMain.getJukeBoxService().getJukeBoxBlock(uuid));
+						} else {
+							gMusicMain.getRadioService().removeRadioJukeBox(uuid);
+						}
+					}
+				}
+				setDefaultBar();
+			});
+			buttonsToAdd.add(button);
 		}
 
 		if(!gMusicMain.getConfigService().G_DISABLE_OPTIONS) {
-			itemStack = new ItemStack(Material.HOPPER);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options"));
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(50, itemStack);
+			item = makeItem(Material.HOPPER, gMusicMain.getMessageService().getMessage("MusicGUI.music-options"));
+			Button button = new Button(item, (itemMeta, click, clicker) -> {
+				setOptionsBar();
+			});
+			buttonsToAdd.add(button);
 		}
 
 		if(!gMusicMain.getConfigService().G_DISABLE_SEARCH && playSettings.getPlayListMode() != PlayListMode.RADIO && !songs.isEmpty() && gMusicMain.getVersionService().isAvailable()) {
-			itemStack = new ItemStack(Material.OAK_SIGN);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(searchKey == null || searchKey.isEmpty() ? gMusicMain.getMessageService().getMessage("MusicGUI.music-search-none") : gMusicMain.getMessageService().getMessage("MusicGUI.music-search", "%Search%", searchKey));
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(51, itemStack);
+			item = makeItem(Material.OAK_SIGN, searchKey == null || searchKey.isEmpty() ? gMusicMain.getMessageService().getMessage("MusicGUI.music-search-none") : gMusicMain.getMessageService().getMessage("MusicGUI.music-search", "%Search%", searchKey));
+			Button button = new Button(item, (itemMeta, click, clicker) -> {
+				if(click == ClickType.LEFT) {
+					MusicInputGUI inputGUI = getInputGUIInstance((input) -> {
+						searchKey = input;
+						setPage(1);
+						setDefaultBar();
+						clicker.openInventory(inventory);
+						searchMode = false;
+						return true;
+					}, ItemMeta::getDisplayName);
+					ItemStack nameItem = makeItem(Material.NAME_TAG, gMusicMain.getMessageService().getMessage("MusicGUI.music-search-menu-field"));
+					searchKey = null;
+					searchMode = true;
+					inputGUI.open(clicker, gMusicMain.getMessageService().getMessage("MusicGUI.music-search-menu-title"), nameItem);
+				} else if(searchKey != null) {
+					searchKey = null;
+					setPage(1);
+					setDefaultBar();
+				}
+			});
+			buttonsToAdd.add(button);
+		}
+
+		for(int i = 0; i < buttonsToAdd.size(); i++) {
+			int slot = 48 + i;
+			if(slot >= 52) break;
+			Button button = buttonsToAdd.get(i);
+			setButton(slot, button);
 		}
 
 		setPauseResumeBar();
@@ -396,35 +295,74 @@ public class MusicGUI {
 
 		PlayState songSettings = gMusicMain.getPlayService().getPlayState(uuid);
 
+		ItemStack item;
+
 		if(songSettings != null) {
-			ItemStack itemStack = new ItemStack(Material.END_CRYSTAL);
-			ItemMeta itemMeta = itemStack.getItemMeta();
-			if(songSettings.isPaused()) {
-				itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-resume"));
-			} else {
-				itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-pause"));
-			}
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(45, itemStack);
+			item = makeItem(Material.END_CRYSTAL, songSettings.isPaused() ? gMusicMain.getMessageService().getMessage("MusicGUI.music-resume") : gMusicMain.getMessageService().getMessage("MusicGUI.music-pause"));
+			Button button = new Button(item, (itemMeta, click, clicker) -> {
+				PlayState currentSongSettings = gMusicMain.getPlayService().getPlayState(uuid);
+				if(currentSongSettings == null) return;
+				switch(playType) {
+					case DEFAULT -> {
+						Player target = Bukkit.getPlayer(uuid);
+						if(target == null) return;
+						if(currentSongSettings.isPaused()) gMusicMain.getPlayService().resumeSong(target);
+						else gMusicMain.getPlayService().pauseSong(target);
+					}
+					case JUKEBOX -> {
+						if(currentSongSettings.isPaused()) gMusicMain.getJukeBoxService().resumeBoxSong(uuid);
+						else gMusicMain.getJukeBoxService().pauseBoxSong(uuid);
+					}
+					case RADIO -> {
+						if(currentSongSettings.isPaused()) gMusicMain.getRadioService().resumeSong();
+						else gMusicMain.getRadioService().pauseSong();
+					}
+				}
+			});
+			setButton(45, button);
 
-			itemStack = new ItemStack(Material.BARRIER);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-stop"));
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(46, itemStack);
+			item = makeItem(Material.BARRIER, gMusicMain.getMessageService().getMessage("MusicGUI.music-stop"));
+			button = new Button(item, (itemMeta, click, clicker) -> {
+				switch(playType) {
+					case DEFAULT -> {
+						Player target = Bukkit.getPlayer(uuid);
+						if(target == null) return;
+						gMusicMain.getPlayService().stopSong(target);
+					}
+					case JUKEBOX -> {
+						gMusicMain.getJukeBoxService().stopBoxSong(uuid);
+					}
+					case RADIO -> {
+						gMusicMain.getRadioService().stopSong();
+					}
+				}
+			});
+			setButton(46, button);
 
-			itemStack = new ItemStack(Material.FEATHER);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-skip"));
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(47, itemStack);
+			item = makeItem(Material.FEATHER, gMusicMain.getMessageService().getMessage("MusicGUI.music-skip"));
+			button = new Button(item, (itemMeta, click, clicker) -> {
+				switch(playType) {
+					case DEFAULT -> {
+						Player target = Bukkit.getPlayer(uuid);
+						if(target == null) return;
+						gMusicMain.getPlayService().playSong(target, gMusicMain.getPlayService().getNextSong(target));
+					}
+					case JUKEBOX -> {
+						gMusicMain.getJukeBoxService().playBoxSong(uuid, gMusicMain.getJukeBoxService().getNextSong(uuid));
+					}
+					case RADIO -> {
+						gMusicMain.getRadioService().playSong(gMusicMain.getRadioService().getNextSong());
+					}
+				}
+			});
+			setButton(47, button);
 
 			return;
 		}
 
-		inventory.setItem(45, null);
-		inventory.setItem(46, null);
-		inventory.setItem(47, null);
+		setButton(45, null);
+		setButton(46, null);
+		setButton(47, null);
 	}
 
 	public void setOptionsBar() {
@@ -432,52 +370,80 @@ public class MusicGUI {
 
 		clearBar();
 
-		ItemStack itemStack = new ItemStack(Material.CHEST);
-		ItemMeta itemMeta = itemStack.getItemMeta();
-		itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-back"));
-		itemStack.setItemMeta(itemMeta);
-		inventory.setItem(45, itemStack);
+		ItemStack item;
+		Button button;
+		List<Button> buttonsToAdd = new ArrayList<>();
+
+		item = makeItem(Material.CHEST, gMusicMain.getMessageService().getMessage("MusicGUI.music-back"));
+		button = new Button(item, (itemMeta, click, clicker) -> {
+			setDefaultBar();
+		});
+		buttonsToAdd.add(button);
+
 		if(playType != PlayType.RADIO) {
-			itemStack = new ItemStack(Material.MAGMA_CREAM);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-volume", "%Volume%", "" + playSettings.getVolume()));
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(46, itemStack);
-			itemStack = new ItemStack(Material.FIREWORK_ROCKET);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-particle", "%Particle%", gMusicMain.getMessageService().getMessage(playSettings.isShowingParticles() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
-			itemMeta.addItemFlags(ItemFlag.values());
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(47, itemStack);
+			item = makeItem(Material.MAGMA_CREAM, gMusicMain.getMessageService().getMessage("MusicGUI.music-options-volume", "%Volume%", "" + playSettings.getVolume()));
+			button = new Button(item, (itemMeta, click, clicker) -> {
+                int volumn = playSettings.getVolume();
+                int step = click == ClickType.SHIFT_LEFT || click == ClickType.SHIFT_RIGHT ? SHIFT_VOLUME_STEPS : VOLUME_STEPS;
+                int newVolumn = click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_VOLUME : (click == ClickType.RIGHT ? Math.max(volumn - step, 0) : Math.min(volumn + step, 100));
+                playSettings.setVolume(newVolumn);
+                itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-volume", "%Volume%", "" + newVolumn));
+            });
+			buttonsToAdd.add(button);
+
+			item = makeItem(Material.FIREWORK_ROCKET, gMusicMain.getMessageService().getMessage("MusicGUI.music-options-particle", "%Particle%", gMusicMain.getMessageService().getMessage(playSettings.isShowingParticles() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+			button = new Button(item, (itemMeta, click, clicker) -> {
+                playSettings.setShowParticles(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_PARTICLES : !playSettings.isShowingParticles());
+                itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-particle", "%Particle%", gMusicMain.getMessageService().getMessage(playSettings.isShowingParticles() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+            });
+			buttonsToAdd.add(button);
 		}
 
 		if(playSettings.getPlayListMode() != PlayListMode.RADIO) {
-			itemStack = new ItemStack(Material.BLAZE_POWDER);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage(playSettings.getPlayMode() == PlayMode.DEFAULT ? "MusicGUI.music-options-play-mode-once" : playSettings.getPlayMode() == PlayMode.SHUFFLE ? "MusicGUI.music-options-play-mode-shuffle" : "MusicGUI.music-options-play-mode-repeat"));
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(48, itemStack);
-			itemStack = new ItemStack(Material.TOTEM_OF_UNDYING);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-reverse", "%Reverse%", gMusicMain.getMessageService().getMessage(playSettings.isReverseMode() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(49, itemStack);
+			item = makeItem(Material.BLAZE_POWDER, gMusicMain.getMessageService().getMessage(playSettings.getPlayMode() == PlayMode.DEFAULT ? "MusicGUI.music-options-play-mode-once" : playSettings.getPlayMode() == PlayMode.SHUFFLE ? "MusicGUI.music-options-play-mode-shuffle" : "MusicGUI.music-options-play-mode-repeat"));
+			button = new Button(item, (itemMeta, click, clicker) -> {
+				int playModeId = playSettings.getPlayMode().getId();
+				PlayMode playMode = PlayMode.byId(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_PLAY_MODE : (click == ClickType.RIGHT ? (playModeId - 1 < 0 ? PlayMode.values().length - 1 : playModeId - 1) : (playModeId + 1 > PlayMode.values().length - 1 ? 0 : playModeId + 1)));
+				playSettings.setPlayMode(playMode);
+				itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage(playMode == PlayMode.DEFAULT ? "MusicGUI.music-options-play-mode-once" : playMode == PlayMode.SHUFFLE ? "MusicGUI.music-options-play-mode-shuffle" : "MusicGUI.music-options-play-mode-repeat"));
+			});
+			buttonsToAdd.add(button);
+
+			item = makeItem(Material.TOTEM_OF_UNDYING, gMusicMain.getMessageService().getMessage("MusicGUI.music-options-reverse", "%Reverse%", gMusicMain.getMessageService().getMessage(playSettings.isReverseMode() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+			button = new Button(item, (itemMeta, click, clicker) -> {
+				if(playSettings.getPlayListMode() == PlayListMode.RADIO) return;
+				playSettings.setReverseMode(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_REVERSE : !playSettings.isReverseMode());
+				itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-reverse", "%Reverse%", gMusicMain.getMessageService().getMessage(playSettings.isReverseMode() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+			});
+			buttonsToAdd.add(button);
 		}
 
 		if(playType == PlayType.JUKEBOX) {
-			itemStack = new ItemStack(Material.REDSTONE);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-range", "%Range%", "" + playSettings.getRange()));
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(50, itemStack);
+			item = makeItem(Material.REDSTONE, gMusicMain.getMessageService().getMessage("MusicGUI.music-options-range", "%Range%", "" + playSettings.getRange()));
+			button = new Button(item, (itemMeta, click, clicker) -> {
+				long range = playSettings.getRange();
+				long step = click == ClickType.SHIFT_LEFT || click == ClickType.SHIFT_RIGHT ? SHIFT_RANGE_STEPS : RANGE_STEPS;
+				long newRange = click == ClickType.MIDDLE ? gMusicMain.getConfigService().J_RANGE : (click == ClickType.RIGHT ? Math.max(range - step, 0) : Math.min(range + step, gMusicMain.getConfigService().J_MAX_RANGE));
+				playSettings.setRange(newRange);
+				itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-range", "%Range%", "" + newRange));
+			});
+			buttonsToAdd.add(button);
 		}
 
 		if(!(playType == PlayType.JUKEBOX && gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS)) {
-			itemStack = new ItemStack(Material.EMERALD);
-			itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-stereo", "%Stereo%", gMusicMain.getMessageService().getMessage(playSettings.isStereo() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
-			itemStack.setItemMeta(itemMeta);
-			inventory.setItem(51, itemStack);
+			item = makeItem(Material.EMERALD, gMusicMain.getMessageService().getMessage("MusicGUI.music-options-stereo", "%Stereo%", gMusicMain.getMessageService().getMessage(playSettings.isStereo() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+			button = new Button(item, (itemMeta, click, clicker) -> {
+				playSettings.setStereo(click == ClickType.MIDDLE ? gMusicMain.getConfigService().PS_D_STEREO : !playSettings.isStereo());
+				itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.music-options-stereo", "%Stereo%", gMusicMain.getMessageService().getMessage(playSettings.isStereo() ? "MusicGUI.music-options-true" : "MusicGUI.music-options-false")));
+			});
+			buttonsToAdd.add(button);
+		}
+
+		for(int i = 0; i < buttonsToAdd.size(); i++) {
+			int slot = 45 + i;
+			if(slot >= 52) break;
+			button = buttonsToAdd.get(i);
+			setButton(slot, button);
 		}
 	}
 
@@ -527,30 +493,18 @@ public class MusicGUI {
 		}
 
 		if(page > 1) {
-			ItemStack itemStack = new ItemStack(Material.ARROW);
-			ItemMeta itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.last-page"));
-			itemStack.setItemMeta(itemMeta);
+			ItemStack itemStack = makeItem(Material.ARROW, gMusicMain.getMessageService().getMessage("MusicGUI.last-page"));
 			inventory.setItem(52, itemStack);
 		} else {
-			ItemStack itemStack = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
-			ItemMeta itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(" ");
-			itemStack.setItemMeta(itemMeta);
+			ItemStack itemStack = makeItem(Material.BLACK_STAINED_GLASS_PANE, " ");
 			inventory.setItem(52, itemStack);
 		}
 
 		if(page < getMaxPageSize(songs.size())) {
-			ItemStack itemStack = new ItemStack(Material.ARROW);
-			ItemMeta itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(gMusicMain.getMessageService().getMessage("MusicGUI.next-page"));
-			itemStack.setItemMeta(itemMeta);
+			ItemStack itemStack = makeItem(Material.ARROW, gMusicMain.getMessageService().getMessage("MusicGUI.next-page"));
 			inventory.setItem(53, itemStack);
 		} else {
-			ItemStack itemStack = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
-			ItemMeta itemMeta = itemStack.getItemMeta();
-			itemMeta.setDisplayName(" ");
-			itemStack.setItemMeta(itemMeta);
+			ItemStack itemStack = makeItem(Material.BLACK_STAINED_GLASS_PANE, " ");
 			inventory.setItem(53, itemStack);
 		}
 	}
@@ -564,5 +518,30 @@ public class MusicGUI {
 	public @NotNull PlaySettings getPlaySettings() { return playSettings; }
 
 	public @NotNull Inventory getInventory() { return inventory; }
+
+	private static ItemStack makeItem(Material material, String displayName) {
+		ItemStack itemStack = new ItemStack(material);
+		ItemMeta itemMeta = itemStack.getItemMeta();
+		itemMeta.setDisplayName(displayName);
+		itemStack.setItemMeta(itemMeta);
+		return itemStack;
+	}
+
+	private record Button(ItemStack item, ClickHandler handler) {}
+
+	@FunctionalInterface
+	private interface ClickHandler {
+		void onClick(ItemMeta itemMeta, ClickType click, HumanEntity clicker);
+	}
+
+	private void setButton(int slot, @Nullable Button button) {
+		if(button == null) {
+			inventory.setItem(slot, makeItem(Material.BLACK_STAINED_GLASS_PANE, " "));
+			buttons.remove(slot);
+		} else {
+			inventory.setItem(slot, button.item);
+			buttons.put(slot, button.handler);
+		}
+	}
 
 }

--- a/core/src/main/java/dev/geco/gmusic/service/ConfigService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/ConfigService.java
@@ -20,6 +20,7 @@ public class ConfigService {
     public boolean S_EXTENDED_RANGE;
     public boolean S_FORCE_RESOURCES;
     public boolean J_LOCATIONAL_SOUNDS;
+    public boolean J_LOCATIONAL_CLOSE_TO_PLAYER;
     public int J_RANGE;
     public int J_MAX_RANGE;
     public int J_VOLUME;
@@ -84,6 +85,7 @@ public class ConfigService {
         S_FORCE_RESOURCES = gMusicMain.getConfig().getBoolean("Options.Sound.force-resources", true);
 
         J_LOCATIONAL_SOUNDS = gMusicMain.getConfig().getBoolean("Options.JukeBox.locational-sounds", true);
+        J_LOCATIONAL_CLOSE_TO_PLAYER = gMusicMain.getConfig().getBoolean("Options.JukeBox.locational-close-to-player", true);
         J_RANGE = gMusicMain.getConfig().getInt("Options.JukeBox.range", 50);
         J_MAX_RANGE = gMusicMain.getConfig().getInt("Options.JukeBox.max-range", 500);
         J_VOLUME = gMusicMain.getConfig().getInt("Options.JukeBox.volume", 100);

--- a/core/src/main/java/dev/geco/gmusic/service/ConfigService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/ConfigService.java
@@ -22,6 +22,7 @@ public class ConfigService {
     public boolean J_LOCATIONAL_SOUNDS;
     public int J_RANGE;
     public int J_MAX_RANGE;
+    public int J_VOLUME;
     public boolean A_SHOW_MESSAGES;
     public boolean A_SHOW_WHILE_PLAYING;
     public boolean R_ACTIVE;
@@ -85,6 +86,7 @@ public class ConfigService {
         J_LOCATIONAL_SOUNDS = gMusicMain.getConfig().getBoolean("Options.JukeBox.locational-sounds", true);
         J_RANGE = gMusicMain.getConfig().getInt("Options.JukeBox.range", 50);
         J_MAX_RANGE = gMusicMain.getConfig().getInt("Options.JukeBox.max-range", 500);
+        J_VOLUME = gMusicMain.getConfig().getInt("Options.JukeBox.volume", 100);
 
         A_SHOW_MESSAGES = gMusicMain.getConfig().getBoolean("Options.ActionBar.show-messages", true);
         A_SHOW_WHILE_PLAYING = gMusicMain.getConfig().getBoolean("Options.ActionBar.show-while-playing", true);

--- a/core/src/main/java/dev/geco/gmusic/service/ConfigService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/ConfigService.java
@@ -35,6 +35,7 @@ public class ConfigService {
     public boolean PS_SAVE_ON_QUIT;
     public int PS_D_PLAYLIST_MODE;
     public int PS_D_VOLUME;
+    public boolean PS_D_STEREO;
     public int PS_D_PLAY_MODE;
     public boolean PS_D_PARTICLES;
     public boolean PS_D_REVERSE;
@@ -101,6 +102,7 @@ public class ConfigService {
         PS_SAVE_ON_QUIT = gMusicMain.getConfig().getBoolean("Options.PlayerSettings.save-on-quit", true);
         PS_D_PLAYLIST_MODE = gMusicMain.getConfig().getInt("Options.PlayerSettings.Default.playlist-mode", 0);
         PS_D_VOLUME = gMusicMain.getConfig().getInt("Options.PlayerSettings.Default.volume", 70);
+        PS_D_STEREO = gMusicMain.getConfig().getBoolean("Options.PlayerSettings.Default.stereo", true);
         PS_D_PLAY_MODE = gMusicMain.getConfig().getInt("Options.PlayerSettings.Default.play-mode", 0);
         PS_D_PARTICLES = gMusicMain.getConfig().getBoolean("Options.PlayerSettings.Default.particles", false);
         PS_D_REVERSE = gMusicMain.getConfig().getBoolean("Options.PlayerSettings.Default.reverse", false);

--- a/core/src/main/java/dev/geco/gmusic/service/DiscService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/DiscService.java
@@ -66,7 +66,6 @@ public class DiscService {
 
 	public void generateDiscPlaySettings(@NotNull UUID uuid, @NotNull Song song) {
 		PlaySettings playSettings = gMusicMain.getPlaySettingsService().generateDefaultPlaySettings(uuid, PlayType.JUKEBOX);
-		playSettings.setRange(gMusicMain.getConfigService().J_RANGE);
 		playSettings.setPlayMode(PlayMode.DEFAULT);
 		playSettings.setShowParticles(true);
 		gMusicMain.getPlayService().setPlayState(uuid, new PlayState(uuid, PlayType.JUKEBOX, song, new Timer(), 0));

--- a/core/src/main/java/dev/geco/gmusic/service/JukeBoxService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/JukeBoxService.java
@@ -242,17 +242,8 @@ public class JukeBoxService {
 
 					for(NotePart notePart : noteParts) {
 						for(Player player : playersInRange.keySet()) {
-							if(notePart.getSound() != null) {
-								float volume = (float) ((playersInRange.get(player) - playSettings.getRange()) * playSettings.getFixedVolume() / (double) -playSettings.getRange()) * notePart.getVolume();
-
-								Location location = gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS ? boxLocation : notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
-
-								if(!gMusicMain.getConfigService().ENVIRONMENT_EFFECTS) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
-								else {
-									if(gMusicMain.getEnvironmentUtil().isPlayerSwimming(player)) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume > 0.4f ? volume - 0.3f : volume, notePart.getPitch() - 0.15f);
-									else player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
-								}
-							} else if(notePart.getStopSound() != null) player.stopSound(notePart.getStopSound(), song.getSoundCategory());
+							if(gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS) gMusicMain.getMusicUtil().playAtLocation(player, notePart, boxLocation, playSettings);
+							else gMusicMain.getMusicUtil().playAtPlayerWithDecay(player, notePart, playersInRange.get(player), playSettings, true);
 						}
 					}
 				}

--- a/core/src/main/java/dev/geco/gmusic/service/JukeBoxService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/JukeBoxService.java
@@ -243,7 +243,7 @@ public class JukeBoxService {
 					for(NotePart notePart : noteParts) {
 						for(Player player : playersInRange.keySet()) {
 							if(gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS) gMusicMain.getMusicUtil().playAtLocation(player, notePart, boxLocation, playSettings);
-							else gMusicMain.getMusicUtil().playAtPlayerWithDecay(player, notePart, playersInRange.get(player), playSettings, true);
+							else gMusicMain.getMusicUtil().playAtPlayerWithDecay(player, notePart, playersInRange.get(player), playSettings);
 						}
 					}
 				}

--- a/core/src/main/java/dev/geco/gmusic/service/JukeBoxService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/JukeBoxService.java
@@ -145,7 +145,6 @@ public class JukeBoxService {
 					block.getZ()
 			);
 			PlaySettings playSettings = gMusicMain.getPlaySettingsService().generateDefaultPlaySettings(uuid, PlayType.JUKEBOX);
-			playSettings.setRange(gMusicMain.getConfigService().J_RANGE);
 			if(playSettings.getPlayListMode() == PlayListMode.RADIO) gMusicMain.getRadioService().addRadioJukeBox(uuid, block);
 			jukeBoxBlocks.put(block, uuid);
 			jukeBoxes.put(uuid, block);

--- a/core/src/main/java/dev/geco/gmusic/service/PlayService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/PlayService.java
@@ -149,7 +149,7 @@ public class PlayService {
 					if(playSettings.isShowingParticles()) player.spawnParticle(Particle.NOTE, player.getEyeLocation().add(random.nextDouble() - 0.5, 0.3, random.nextDouble() - 0.5), 0, random.nextDouble(), random.nextDouble(), random.nextDouble(), 1);
 
 					for(NotePart notePart : noteParts) {
-						gMusicMain.getMusicUtil().playAtPlayer(player, notePart, playSettings, true);
+						gMusicMain.getMusicUtil().playAtPlayer(player, notePart, playSettings);
 					}
 				}
 

--- a/core/src/main/java/dev/geco/gmusic/service/PlayService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/PlayService.java
@@ -10,7 +10,6 @@ import dev.geco.gmusic.model.PlaySettings;
 import dev.geco.gmusic.model.Song;
 import dev.geco.gmusic.model.PlayState;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -150,17 +149,7 @@ public class PlayService {
 					if(playSettings.isShowingParticles()) player.spawnParticle(Particle.NOTE, player.getEyeLocation().add(random.nextDouble() - 0.5, 0.3, random.nextDouble() - 0.5), 0, random.nextDouble(), random.nextDouble(), random.nextDouble(), 1);
 
 					for(NotePart notePart : noteParts) {
-						if(notePart.getSound() != null) {
-							float volume = playSettings.getFixedVolume() * notePart.getVolume();
-
-							Location location = notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
-
-							if(!gMusicMain.getConfigService().ENVIRONMENT_EFFECTS) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
-							else {
-								if(gMusicMain.getEnvironmentUtil().isPlayerSwimming(player)) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume > 0.4f ? volume - 0.3f : volume, notePart.getPitch() - 0.15f);
-								else player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
-							}
-						} else if(notePart.getStopSound() != null) player.stopSound(notePart.getStopSound(), song.getSoundCategory());
+						gMusicMain.getMusicUtil().playAtPlayer(player, notePart, playSettings, true);
 					}
 				}
 

--- a/core/src/main/java/dev/geco/gmusic/service/PlaySettingsService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/PlaySettingsService.java
@@ -28,7 +28,7 @@ public class PlaySettingsService {
 
 	public void createDataTables() {
 		try {
-			gMusicMain.getDataService().execute("CREATE TABLE IF NOT EXISTS gmusic_play_setting (uuid CHAR(36) PRIMARY KEY, play_type INTEGER, play_list_mode INTEGER, volume INTEGER, play_mode INTEGER, show_particles INTEGER, reverse_mode INTEGER, toggle_mode INTEGER, range INTEGER);");
+			gMusicMain.getDataService().execute("CREATE TABLE IF NOT EXISTS gmusic_play_setting (uuid CHAR(36) PRIMARY KEY, play_type INTEGER, play_list_mode INTEGER, volume INTEGER, play_mode INTEGER, show_particles INTEGER, reverse_mode INTEGER, toggle_mode INTEGER, range INTEGER, stereo INTEGER);");
 			gMusicMain.getDataService().execute("CREATE TABLE IF NOT EXISTS gmusic_play_setting_favorite (uuid CHAR(36), song_id TEXT, FOREIGN KEY (uuid) REFERENCES gmusic_play_setting(uuid) ON DELETE CASCADE ON UPDATE CASCADE);");
 		} catch(Throwable e) { gMusicMain.getLogger().log(Level.SEVERE, "Could not create play settings database tables!", e); }
 	}
@@ -52,6 +52,7 @@ public class PlaySettingsService {
 							playSettingsData.getBoolean("reverse_mode"),
 							playSettingsData.getBoolean("toggle_mode"),
 							playSettingsData.getLong("range"),
+							playSettingsData.getBoolean("stereo"),
 							new ArrayList<>()
 					));
 				}
@@ -98,6 +99,7 @@ public class PlaySettingsService {
 							playSettingsData.getBoolean("reverse_mode"),
 							playSettingsData.getBoolean("toggle_mode"),
 							playSettingsData.getLong("range"),
+							playSettingsData.getBoolean("stereo"),
 							favorites
 					);
 				}
@@ -123,6 +125,7 @@ public class PlaySettingsService {
 				gMusicMain.getConfigService().PS_D_REVERSE,
 				false,
 				0,
+				gMusicMain.getConfigService().PS_D_STEREO,
 				new ArrayList<>()
 		);
 
@@ -146,9 +149,10 @@ public class PlaySettingsService {
 					show_particles,
 					reverse_mode,
 					toggle_mode,
-					range
+					range,
+					stereo
 				)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 				ON CONFLICT(uuid) DO UPDATE SET
 					play_type      = excluded.play_type,
 					play_list_mode = excluded.play_list_mode,
@@ -157,7 +161,8 @@ public class PlaySettingsService {
 					show_particles = excluded.show_particles,
 					reverse_mode   = excluded.reverse_mode,
 					toggle_mode    = excluded.toggle_mode,
-					range          = excluded.range
+					range          = excluded.range,
+					stereo         = excluded.stereo
 				""";
 
 				default -> """
@@ -170,9 +175,10 @@ public class PlaySettingsService {
 					show_particles,
 					reverse_mode,
 					toggle_mode,
-					range
+					range,
+					stereo
 				)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) AS new
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AS new
 				ON DUPLICATE KEY UPDATE
 					play_type      = new.play_type,
 					play_list_mode = new.play_list_mode,
@@ -181,7 +187,8 @@ public class PlaySettingsService {
 					show_particles = new.show_particles,
 					reverse_mode   = new.reverse_mode,
 					toggle_mode    = new.toggle_mode,
-					range          = new.range
+					range          = new.range,
+					stereo         = new.stereo,
 				""";
 			};
 
@@ -195,7 +202,8 @@ public class PlaySettingsService {
 					playSettings.isShowingParticles(),
 					playSettings.isReverseMode(),
 					playSettings.isToggleMode(),
-					playSettings.getRange()
+					playSettings.getRange(),
+					playSettings.isStereo()
 			);
 
 			if(playSettings.getFavorites().isEmpty()) return;

--- a/core/src/main/java/dev/geco/gmusic/service/PlaySettingsService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/PlaySettingsService.java
@@ -119,12 +119,12 @@ public class PlaySettingsService {
 				uuid,
 				playType,
 				PlayListMode.byId(gMusicMain.getConfigService().PS_D_PLAYLIST_MODE),
-				gMusicMain.getConfigService().PS_D_VOLUME,
+				playType == PlayType.JUKEBOX ? gMusicMain.getConfigService().J_VOLUME : gMusicMain.getConfigService().PS_D_VOLUME,
 				PlayMode.byId(gMusicMain.getConfigService().PS_D_PLAY_MODE),
 				gMusicMain.getConfigService().PS_D_PARTICLES,
 				gMusicMain.getConfigService().PS_D_REVERSE,
 				false,
-				0,
+				playType == PlayType.JUKEBOX ? gMusicMain.getConfigService().J_RANGE : 0,
 				gMusicMain.getConfigService().PS_D_STEREO,
 				new ArrayList<>()
 		);

--- a/core/src/main/java/dev/geco/gmusic/service/RadioService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/RadioService.java
@@ -136,7 +136,7 @@ public class RadioService {
 						for(Player player : players) {
 							if(player == null) continue;
 							PlaySettings playerPlaySettings = gMusicMain.getPlaySettingsService().getPlaySettings(player.getUniqueId(), PlayType.DEFAULT);
-							gMusicMain.getMusicUtil().playAtPlayer(player, notePart, playerPlaySettings, true);
+							gMusicMain.getMusicUtil().playAtPlayer(player, notePart, playerPlaySettings);
 						}
 
 						for(Map.Entry<UUID, Block> radioJukeBox : radioJukeBoxBlocks.entrySet()) {
@@ -145,7 +145,7 @@ public class RadioService {
 							HashMap<Player, Double> playersInRange = gMusicMain.getJukeBoxService().getPlayersInRange(boxLocation, jukeBoxPlaySettings.getRange());
 							for(Player player : playersInRange.keySet()) {
 								if(gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS) gMusicMain.getMusicUtil().playAtLocation(player, notePart, boxLocation, playSettings);
-								else gMusicMain.getMusicUtil().playAtPlayerWithDecay(player, notePart, playersInRange.get(player), playSettings, true);
+								else gMusicMain.getMusicUtil().playAtPlayerWithDecay(player, notePart, playersInRange.get(player), playSettings);
 							}
 						}
 					}

--- a/core/src/main/java/dev/geco/gmusic/service/RadioService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/RadioService.java
@@ -135,22 +135,8 @@ public class RadioService {
 					for(NotePart notePart : noteParts) {
 						for(Player player : players) {
 							if(player == null) continue;
-							if(notePart.getSound() != null) {
-								PlaySettings playerPlaySettings = gMusicMain.getPlaySettingsService().getPlaySettings(player.getUniqueId(), PlayType.DEFAULT);
-								float volume = playerPlaySettings.getFixedVolume() * notePart.getVolume();
-
-								Location location = notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
-
-								if(!gMusicMain.getConfigService().ENVIRONMENT_EFFECTS)
-									player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
-								else {
-									if(gMusicMain.getEnvironmentUtil().isPlayerSwimming(player))
-										player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume > 0.4f ? volume - 0.3f : volume, notePart.getPitch() - 0.15f);
-									else
-										player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
-								}
-							} else if(notePart.getStopSound() != null)
-								player.stopSound(notePart.getStopSound(), song.getSoundCategory());
+							PlaySettings playerPlaySettings = gMusicMain.getPlaySettingsService().getPlaySettings(player.getUniqueId(), PlayType.DEFAULT);
+							gMusicMain.getMusicUtil().playAtPlayer(player, notePart, playerPlaySettings, true);
 						}
 
 						for(Map.Entry<UUID, Block> radioJukeBox : radioJukeBoxBlocks.entrySet()) {
@@ -158,17 +144,8 @@ public class RadioService {
 							Location boxLocation = radioJukeBox.getValue().getLocation().add(0.5, 0, 0.5);
 							HashMap<Player, Double> playersInRange = gMusicMain.getJukeBoxService().getPlayersInRange(boxLocation, jukeBoxPlaySettings.getRange());
 							for(Player player : playersInRange.keySet()) {
-								if(notePart.getSound() != null) {
-									float volume = (float) ((playersInRange.get(player) - jukeBoxPlaySettings.getRange()) * jukeBoxPlaySettings.getFixedVolume() / (double) -jukeBoxPlaySettings.getRange()) * notePart.getVolume();
-
-									Location location = gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS ? boxLocation :notePart.getDistance() == 0 ? player.getEyeLocation() : gMusicMain.getSteroNoteUtil().convertToStero(player.getEyeLocation(), notePart.getDistance());
-
-									if(!gMusicMain.getConfigService().ENVIRONMENT_EFFECTS) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
-									else {
-										if(gMusicMain.getEnvironmentUtil().isPlayerSwimming(player)) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume > 0.4f ? volume - 0.3f : volume, notePart.getPitch() - 0.15f);
-										else player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
-									}
-								} else if(notePart.getStopSound() != null) player.stopSound(notePart.getStopSound(), song.getSoundCategory());
+								if(gMusicMain.getConfigService().J_LOCATIONAL_SOUNDS) gMusicMain.getMusicUtil().playAtLocation(player, notePart, boxLocation, playSettings);
+								else gMusicMain.getMusicUtil().playAtPlayerWithDecay(player, notePart, playersInRange.get(player), playSettings, true);
 							}
 						}
 					}

--- a/core/src/main/java/dev/geco/gmusic/util/MusicUtil.java
+++ b/core/src/main/java/dev/geco/gmusic/util/MusicUtil.java
@@ -1,0 +1,53 @@
+package dev.geco.gmusic.util;
+
+import dev.geco.gmusic.GMusicMain;
+import dev.geco.gmusic.model.NotePart;
+import dev.geco.gmusic.model.PlaySettings;
+import dev.geco.gmusic.model.Song;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class MusicUtil {
+
+    private final GMusicMain gMusicMain;
+
+    public MusicUtil(GMusicMain gMusicMain) {
+        this.gMusicMain = gMusicMain;
+    }
+
+    public void playAtPlayer(@NotNull Player player, @NotNull NotePart notePart, @NotNull PlaySettings playSettings, boolean stereo) {
+        play(player, notePart, player.getEyeLocation(), playSettings.getFixedVolume(), stereo);
+    }
+    public void playAtLocation(@NotNull Player player, @NotNull NotePart notePart, @NotNull Location origin, @NotNull PlaySettings playSettings) {
+        float volume = rangeToVolume(playSettings.getRange()) * playSettings.getFixedVolume();
+        play(player, notePart, origin, volume, false);
+    }
+    public void playAtPlayerWithDecay(@NotNull Player player, @NotNull NotePart notePart, double distanceToOrigin, @NotNull PlaySettings playSettings, boolean stereo) {
+        float volume = simulateVolumeDecay(distanceToOrigin, playSettings.getRange()) * playSettings.getFixedVolume();
+        play(player, notePart, player.getEyeLocation(), volume, stereo);
+    }
+
+    private void play(@NotNull Player player, @NotNull NotePart notePart, @NotNull Location origin, float fixedVolume, boolean stereo) {
+        Song song = notePart.getNote().getSong();
+        if(notePart.getSound() != null) {
+            float volume = fixedVolume * notePart.getVolume();
+
+            Location location = !stereo || notePart.getDistance() == 0 ? origin : gMusicMain.getSteroNoteUtil().convertToStero(origin, notePart.getDistance());
+
+            if(!gMusicMain.getConfigService().ENVIRONMENT_EFFECTS) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
+            else {
+                if(gMusicMain.getEnvironmentUtil().isPlayerSwimming(player)) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume > 0.4f ? volume - 0.3f : volume, notePart.getPitch() - 0.15f);
+                else player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
+            }
+        } else if(notePart.getStopSound() != null) player.stopSound(notePart.getStopSound(), song.getSoundCategory());
+    }
+
+    private float rangeToVolume(double range) {
+        return (float) (1.0 + (range - 16) * 0.06);
+    }
+    private float simulateVolumeDecay(double playerDistance, double range) {
+        return (float) ((range - playerDistance) / range);
+    }
+
+}

--- a/core/src/main/java/dev/geco/gmusic/util/MusicUtil.java
+++ b/core/src/main/java/dev/geco/gmusic/util/MusicUtil.java
@@ -20,16 +20,16 @@ public class MusicUtil {
         this.gMusicMain = gMusicMain;
     }
 
-    public void playAtPlayer(@NotNull Player player, @NotNull NotePart notePart, @NotNull PlaySettings playSettings, boolean stereo) {
-        play(player, notePart, null, playSettings.getFixedVolume(), stereo);
+    public void playAtPlayer(@NotNull Player player, @NotNull NotePart notePart, @NotNull PlaySettings playSettings) {
+        play(player, notePart, null, playSettings.getFixedVolume(), playSettings.isStereo());
     }
     public void playAtLocation(@NotNull Player player, @NotNull NotePart notePart, @NotNull Location origin, @NotNull PlaySettings playSettings) {
         float volume = rangeToVolume(playSettings.getRange()) * playSettings.getFixedVolume();
         play(player, notePart, origin, volume, false);
     }
-    public void playAtPlayerWithDecay(@NotNull Player player, @NotNull NotePart notePart, double distanceToOrigin, @NotNull PlaySettings playSettings, boolean stereo) {
+    public void playAtPlayerWithDecay(@NotNull Player player, @NotNull NotePart notePart, double distanceToOrigin, @NotNull PlaySettings playSettings) {
         float volume = simulateVolumeDecay(distanceToOrigin, playSettings.getRange()) * playSettings.getFixedVolume();
-        play(player, notePart, null, volume, stereo);
+        play(player, notePart, null, volume, playSettings.isStereo());
     }
 
     private void play(@NotNull Player player, @NotNull NotePart notePart, @Nullable Location origin, float fixedVolume, boolean stereo) {

--- a/core/src/main/java/dev/geco/gmusic/util/MusicUtil.java
+++ b/core/src/main/java/dev/geco/gmusic/util/MusicUtil.java
@@ -4,9 +4,13 @@ import dev.geco.gmusic.GMusicMain;
 import dev.geco.gmusic.model.NotePart;
 import dev.geco.gmusic.model.PlaySettings;
 import dev.geco.gmusic.model.Song;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
 import org.bukkit.Location;
+import org.bukkit.SoundCategory;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class MusicUtil {
 
@@ -17,7 +21,7 @@ public class MusicUtil {
     }
 
     public void playAtPlayer(@NotNull Player player, @NotNull NotePart notePart, @NotNull PlaySettings playSettings, boolean stereo) {
-        play(player, notePart, player.getEyeLocation(), playSettings.getFixedVolume(), stereo);
+        play(player, notePart, null, playSettings.getFixedVolume(), stereo);
     }
     public void playAtLocation(@NotNull Player player, @NotNull NotePart notePart, @NotNull Location origin, @NotNull PlaySettings playSettings) {
         float volume = rangeToVolume(playSettings.getRange()) * playSettings.getFixedVolume();
@@ -25,22 +29,32 @@ public class MusicUtil {
     }
     public void playAtPlayerWithDecay(@NotNull Player player, @NotNull NotePart notePart, double distanceToOrigin, @NotNull PlaySettings playSettings, boolean stereo) {
         float volume = simulateVolumeDecay(distanceToOrigin, playSettings.getRange()) * playSettings.getFixedVolume();
-        play(player, notePart, player.getEyeLocation(), volume, stereo);
+        play(player, notePart, null, volume, stereo);
     }
 
-    private void play(@NotNull Player player, @NotNull NotePart notePart, @NotNull Location origin, float fixedVolume, boolean stereo) {
+    private void play(@NotNull Player player, @NotNull NotePart notePart, @Nullable Location origin, float fixedVolume, boolean stereo) {
         Song song = notePart.getNote().getSong();
         if(notePart.getSound() != null) {
-            float volume = fixedVolume * notePart.getVolume();
-
-            Location location = !stereo || notePart.getDistance() == 0 ? origin : gMusicMain.getSteroNoteUtil().convertToStero(origin, notePart.getDistance());
-
-            if(!gMusicMain.getConfigService().ENVIRONMENT_EFFECTS) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
-            else {
-                if(gMusicMain.getEnvironmentUtil().isPlayerSwimming(player)) player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume > 0.4f ? volume - 0.3f : volume, notePart.getPitch() - 0.15f);
-                else player.playSound(location, notePart.getSound(), song.getSoundCategory(), volume, notePart.getPitch());
+            Sound sound = getSound(player, notePart, fixedVolume);
+            if(stereo) {
+                Location originLocation = origin == null ? player.getEyeLocation() : origin;
+                Location stereoLocation = notePart.getDistance() == 0 ? originLocation : gMusicMain.getSteroNoteUtil().convertToStero(originLocation, notePart.getDistance());
+                player.playSound(stereoLocation, notePart.getSound(), song.getSoundCategory(), sound.volume(), sound.pitch());
+            } else {
+                if(origin == null) player.playSound(sound, Sound.Emitter.self());
+                else player.playSound(origin, notePart.getSound(), song.getSoundCategory(), sound.volume(), sound.pitch());
             }
         } else if(notePart.getStopSound() != null) player.stopSound(notePart.getStopSound(), song.getSoundCategory());
+    }
+
+    private Sound getSound(@NotNull Player player, @NotNull NotePart notePart, float fixedVolume) {
+        Key sound = Key.key(notePart.getSound());
+        SoundCategory category = notePart.getNote().getSong().getSoundCategory();
+        float volume = fixedVolume * notePart.getVolume();
+        if(gMusicMain.getConfigService().ENVIRONMENT_EFFECTS && gMusicMain.getEnvironmentUtil().isPlayerSwimming(player))
+            return Sound.sound(sound, category, volume > 0.4f ? volume - 0.3f : volume, notePart.getPitch() - 0.15f);
+        else
+            return Sound.sound(sound, category, volume, notePart.getPitch());
     }
 
     private float rangeToVolume(double range) {

--- a/core/src/main/java/dev/geco/gmusic/util/MusicUtil.java
+++ b/core/src/main/java/dev/geco/gmusic/util/MusicUtil.java
@@ -9,10 +9,13 @@ import net.kyori.adventure.sound.Sound;
 import org.bukkit.Location;
 import org.bukkit.SoundCategory;
 import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class MusicUtil {
+
+    private static final double SIMULATED_RANGE_CAP = 8.0;
 
     private final GMusicMain gMusicMain;
 
@@ -24,8 +27,13 @@ public class MusicUtil {
         play(player, notePart, null, playSettings.getFixedVolume(), playSettings.isStereo());
     }
     public void playAtLocation(@NotNull Player player, @NotNull NotePart notePart, @NotNull Location origin, @NotNull PlaySettings playSettings) {
-        float volume = rangeToVolume(playSettings.getRange()) * playSettings.getFixedVolume();
-        play(player, notePart, origin, volume, false);
+        if(gMusicMain.getConfigService().J_LOCATIONAL_CLOSE_TO_PLAYER) {
+            Location playAt = moveTowardsOrigin(player.getEyeLocation(), origin);
+            play(player, notePart, playAt, playSettings.getFixedVolume(), false);
+        } else {
+            float volume = rangeToVolume(playSettings.getRange()) * playSettings.getFixedVolume();
+            play(player, notePart, origin, volume, false);
+        }
     }
     public void playAtPlayerWithDecay(@NotNull Player player, @NotNull NotePart notePart, double distanceToOrigin, @NotNull PlaySettings playSettings) {
         float volume = simulateVolumeDecay(distanceToOrigin, playSettings.getRange()) * playSettings.getFixedVolume();
@@ -57,6 +65,12 @@ public class MusicUtil {
             return Sound.sound(sound, category, volume, notePart.getPitch());
     }
 
+    private Location moveTowardsOrigin(Location listener, Location origin) {
+        Vector listenerToOrigin = origin.toVector().subtract(listener.toVector());
+        double lengthSqr = listenerToOrigin.lengthSquared();
+        if(lengthSqr <= SIMULATED_RANGE_CAP * SIMULATED_RANGE_CAP) return origin;
+        return listener.clone().add(listenerToOrigin.normalize().multiply(SIMULATED_RANGE_CAP));
+    }
     private float rangeToVolume(double range) {
         return (float) (1.0 + (range - 16) * 0.06);
     }

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -20,6 +20,10 @@ Options:
     # Defines whether a jukebox should play music at the jukebox's location
     locational-sounds: true
 
+    # Defines whether to play sounds close to the player but still in the jukebox's direction (if locational-sounds true)
+    # Fixes issues with too loud or too soft instruments
+    locational-close-to-player: true
+
     # Defines the range a player can hear the sound of a jukebox
     range: 50
 

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -66,6 +66,7 @@ Options:
     Default:
       playlist-mode: 0
       volume: 70
+      stereo: false
       play-mode: 0
       particles: true
       reverse: false

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -26,6 +26,9 @@ Options:
     # Defines the max range of a jukebox
     max-range: 500
 
+    # Defines the default volume of a jukebox
+    volume: 100
+
   ActionBar:
     # Defines whether there should be actionbar messages
     show-messages: true

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -20,10 +20,10 @@ Options:
     # Defines whether a jukebox should play music at the jukebox's location
     locational-sounds: true
 
-    # Defines the range a player can hear the sound of a jukebox (Only locational-sounds: false)
+    # Defines the range a player can hear the sound of a jukebox
     range: 50
 
-    # Defines the max range of a jukebox (Only locational-sounds: false)
+    # Defines the max range of a jukebox
     max-range: 500
 
   ActionBar:

--- a/resources/lang/en_us.yml
+++ b/resources/lang/en_us.yml
@@ -87,6 +87,7 @@ MusicGUI:
 
   music-options: "&cOptions"
   music-options-volume: "&aVolume:&b %Volume%%"
+  music-options-stereo: "&aStereo:&6 %Stereo%"
   music-options-play-mode-once: "&aMode:&6 Once"
   music-options-play-mode-shuffle: "&aMode:&6 Shuffle"
   music-options-play-mode-repeat: "&aMode:&6 Repeat"


### PR DESCRIPTION
If a sound is playing at the player's position, moving quickly or turning your head can cause the sound to lag behind you, which is especially noticeable with long sounds such as portal wooshes. Sounds can instead follow the player as they move with `Sound.Emitter.self()`. However, since stereo works by modifying the location sound plays from, there is no easy way to let stereo sounds follow the player. So, this PR:
- Re-introduces the stereo toggle from #18.
- If stereo is disabled, sounds follow the player and play cleanly no matter how fast the player is going.

If a sound is playing at a jukebox (location jukebox sounds enabled), differences in attenuation distance (defined client-side in [sounds.json](https://minecraft.wiki/w/Sounds.json#File_structure)) mean players far away from the jukebox can hear some instruments but not others. For example, note blocks can only be heard close to the jukebox, while portal wooshes can be heard far away, giving the illusion of "random" portal noises. To fix this issue, this PR:
- Boosts all instrument volume by `1 + (range - 16) * 0.06` (same formula NBS datapack export uses) so quieter instruments can be heard across the entire jukebox range. Volume > 1 does not make the instrument any louder, but it does increase the attenuation distance.
- Re-enables configuring jukebox range.
- Sets the default jukebox volume to 100% since lower volumes cause instruments with lower attenuation distance to cut out earlier.

These changes fix several issues I've received from players and make the listening experience much more pleasant.