### PR TITLE
Improve custom instrument support by fetching sound event list

### DIFF
--- a/core/src/main/java/dev/geco/gmusic/GMusicMain.java
+++ b/core/src/main/java/dev/geco/gmusic/GMusicMain.java
@@ -16,21 +16,9 @@ import dev.geco.gmusic.link.PlaceholderAPILink;
 import dev.geco.gmusic.link.PlotSquaredLink;
 import dev.geco.gmusic.link.WorldGuardLink;
 import dev.geco.gmusic.metric.BStatsMetric;
-import dev.geco.gmusic.service.ConfigService;
-import dev.geco.gmusic.service.DataService;
-import dev.geco.gmusic.service.DiscService;
-import dev.geco.gmusic.service.JukeBoxService;
-import dev.geco.gmusic.service.MessageService;
+import dev.geco.gmusic.service.*;
 import dev.geco.gmusic.service.converter.MidiConverter;
 import dev.geco.gmusic.service.converter.NBSConverter;
-import dev.geco.gmusic.service.PermissionService;
-import dev.geco.gmusic.service.PlaySettingsService;
-import dev.geco.gmusic.service.PlayService;
-import dev.geco.gmusic.service.RadioService;
-import dev.geco.gmusic.service.SongService;
-import dev.geco.gmusic.service.TaskService;
-import dev.geco.gmusic.service.UpdateService;
-import dev.geco.gmusic.service.VersionService;
 import dev.geco.gmusic.service.converter.WavConverter;
 import dev.geco.gmusic.service.message.PaperMessageService;
 import dev.geco.gmusic.service.message.SpigotMessageService;
@@ -57,6 +45,7 @@ public class GMusicMain extends JavaPlugin {
     private PermissionService permissionService;
     private TaskService taskService;
     private DataService dataService;
+    private SoundEventService soundEventService;
     private SongService songService;
     private PlayService playService;
     private PlaySettingsService playSettingsService;
@@ -92,6 +81,8 @@ public class GMusicMain extends JavaPlugin {
     public TaskService getTaskService() { return taskService; }
 
     public DataService getDataService() { return dataService; }
+
+    public SoundEventService getSoundEventService() { return soundEventService; }
 
     public SongService getSongService() { return songService; }
 
@@ -184,6 +175,7 @@ public class GMusicMain extends JavaPlugin {
 
     private void loadSettings(CommandSender sender) {
         if(!connectDatabase(sender)) return;
+        soundEventService.loadSoundEvents();
         songService.loadSongs();
         playService.createDataTables();
         playSettingsService.createDataTables();

--- a/core/src/main/java/dev/geco/gmusic/model/CustomInstrument.java
+++ b/core/src/main/java/dev/geco/gmusic/model/CustomInstrument.java
@@ -1,19 +1,27 @@
 package dev.geco.gmusic.model;
 
+import dev.geco.gmusic.GMusicMain;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
 
 public class CustomInstrument implements Instrument {
 
     private final String sound;
+    private final boolean isKnownSoundEvent;
     private final int key;
 
     public CustomInstrument(String sound, int key) {
-        this.sound = sound;
+        Optional<String> soundEvent = GMusicMain.getInstance().getSoundEventService().getSoundEvent(sound);
+        this.sound = soundEvent.orElse(sound);
+        this.isKnownSoundEvent = soundEvent.isPresent();
         this.key = key;
     }
 
     @Override
     public @NotNull String getSound() { return sound; }
+
+    public boolean isKnownSoundEvent() { return isKnownSoundEvent; }
 
     @Override
     public int getInstrumentKey() { return key; }

--- a/core/src/main/java/dev/geco/gmusic/service/ConfigService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/ConfigService.java
@@ -17,6 +17,7 @@ public class ConfigService {
     public String L_LANG;
     public boolean L_CLIENT_LANG;
     public boolean CHECK_FOR_UPDATE;
+    public boolean DOWNLOAD_SOUND_EVENTS;
     public boolean S_EXTENDED_RANGE;
     public boolean S_FORCE_RESOURCES;
     public boolean J_LOCATIONAL_SOUNDS;
@@ -77,6 +78,7 @@ public class ConfigService {
         L_CLIENT_LANG = gMusicMain.getConfig().getBoolean("Lang.client-lang", true);
 
         CHECK_FOR_UPDATE = gMusicMain.getConfig().getBoolean("Options.check-for-update", true);
+        DOWNLOAD_SOUND_EVENTS = gMusicMain.getConfig().getBoolean("Options.download-sound-events", true);
 
         S_EXTENDED_RANGE = gMusicMain.getConfig().getBoolean("Options.Sound.extened-range", true);
         S_FORCE_RESOURCES = gMusicMain.getConfig().getBoolean("Options.Sound.force-resources", true);

--- a/core/src/main/java/dev/geco/gmusic/service/SoundEventService.java
+++ b/core/src/main/java/dev/geco/gmusic/service/SoundEventService.java
@@ -1,0 +1,196 @@
+package dev.geco.gmusic.service;
+
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+import dev.geco.gmusic.GMusicMain;
+import io.papermc.paper.ServerBuildInfo;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.*;
+import java.lang.reflect.Type;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
+
+public class SoundEventService {
+
+    private static final Gson GSON = initGson();
+    private static final URL VERSION_MANIFEST_URL = url("https://piston-meta.mojang.com/mc/game/version_manifest_v2.json");
+    private static final URI ASSET_URL_BASE = uri("https://resources.download.minecraft.net");
+
+    private final GMusicMain gMusicMain;
+    private @Nullable Map<String, String> soundNameToEvent = null;
+
+    public SoundEventService(GMusicMain gMusicMain) {
+        this.gMusicMain = gMusicMain;
+    }
+
+    public void loadSoundEvents() {
+        if(gMusicMain.getConfigService().DOWNLOAD_SOUND_EVENTS) {
+            Path cachePath = gMusicMain.getDataPath().resolve("sound_cache.json");
+            SoundEventCache cached = readCache(cachePath);
+
+            String currentVersion = ServerBuildInfo.buildInfo().minecraftVersionId();
+            try {
+                if(cached != null && currentVersion.equals(cached.version))
+                    soundNameToEvent = cached.soundMap;
+                else {
+                    soundNameToEvent = fetchSoundMapping(currentVersion);
+                    SoundEventCache toCache = new SoundEventCache(currentVersion, soundNameToEvent);
+                    writeCache(cachePath, toCache);
+                }
+            } catch(Throwable e) {
+                gMusicMain.getLogger().log(Level.WARNING, "Fetching sound events failed", e);
+                if(cached != null) soundNameToEvent = cached.soundMap;
+            }
+        }
+        if(soundNameToEvent == null) gMusicMain.getLogger().warning("Sound events are not loaded, some custom instruments may not work");
+    }
+
+    private @Nullable SoundEventService.SoundEventCache readCache(Path path) {
+        if(!Files.exists(path)) return null;
+        try {
+            return Files.exists(path) ? read(path, SoundEventCache.class) : null;
+        } catch(Throwable e) {
+            gMusicMain.getLogger().log(Level.WARNING, "Loading sound event cache failed", e);
+            return null;
+        }
+    }
+    private void writeCache(Path path, SoundEventCache soundEventCache) {
+        try {
+            write(path, soundEventCache);
+        } catch(Throwable e) {
+            gMusicMain.getLogger().log(Level.WARNING, "Saving sound event cache failed", e);
+        }
+    }
+
+    private record SoundEventCache(
+            String version,
+            Map<String, String> soundMap
+    ) {}
+
+    private Map<String, String> fetchSoundMapping(String version) throws IOException {
+        gMusicMain.getLogger().info("Downloading sound events...");
+
+        VersionManifest versionManifest = fetch(VERSION_MANIFEST_URL, VersionManifest.class);
+        URL clientJsonUrl = versionManifest.versions.stream()
+                .filter(v -> version.equals(v.id))
+                .findAny()
+                .map(v -> v.url)
+                .orElseThrow();
+
+        ClientJson clientJson = fetch(clientJsonUrl, ClientJson.class);
+        URL assetsUrl = clientJson.assetIndex.url;
+
+        Assets assets = fetch(assetsUrl, Assets.class);
+        String hash = assets.objects.get("minecraft/sounds.json").hash;
+        URL soundsJsonUrl = ASSET_URL_BASE.resolve(hash.substring(0, 2) + "/" + hash).toURL();
+
+        Map<String, SoundEvent> soundsJson = fetch(soundsJsonUrl, SOUNDS_JSON_TYPE);
+        Map<String, String> soundNameToEvent = new HashMap<>();
+        for(Map.Entry<String, SoundEvent> entry : soundsJson.entrySet()) {
+            String eventId = entry.getKey();
+            SoundEvent soundEvent = entry.getValue();
+            for(Sound sound : soundEvent.sounds) soundNameToEvent.put(sound.name, eventId);
+        }
+        gMusicMain.getLogger().info("Sound events downloaded");
+        return soundNameToEvent;
+    }
+
+    private static <T> T fetch(URL source, Class<T> clazz) throws IOException {
+        return GSON.fromJson(new InputStreamReader(source.openStream()), clazz);
+    }
+    private static <T> T fetch(URL source, TypeToken<T> typeToken) throws IOException {
+        return GSON.fromJson(new InputStreamReader(source.openStream()), typeToken);
+    }
+    private static <T> T read(Path path, Class<T> clazz) throws IOException {
+        return GSON.fromJson(Files.newBufferedReader(path, StandardCharsets.UTF_8), clazz);
+    }
+    private static <T> void write(Path path, T obj) throws IOException {
+        try(Writer writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+            GSON.toJson(obj, writer);
+        }
+    }
+
+    private record VersionManifest(
+            List<Version> versions
+    ) {}
+    private record Version(
+            String id,
+            URL url
+    ) {}
+
+    private record ClientJson(
+            AssetIndex assetIndex
+    ) {}
+    private record AssetIndex(
+            URL url
+    ) {}
+
+    private record Assets(
+            Map<String, Asset> objects
+    ) {}
+    private record Asset(
+            String hash
+    ) {}
+
+    private static final TypeToken<Map<String, SoundEvent>> SOUNDS_JSON_TYPE = new TypeToken<>(){};
+    private record SoundEvent(
+            List<Sound> sounds
+    ) {}
+    private record Sound(
+            String name
+    ) {}
+
+    // A sound can either be:
+    private static class SoundDeserializer implements JsonDeserializer<Sound> {
+        @Override
+        public Sound deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            // An object: {"name": "minecraft:sound_id"}
+            if(json.isJsonObject()) return new Sound(json.getAsJsonObject().get("name").getAsString());
+            // A string: "minecraft:sound_id"
+            return new Sound(json.getAsString());
+        }
+    }
+
+    private static Gson initGson() {
+        GsonBuilder gson = new GsonBuilder();
+        gson.registerTypeAdapter(Sound.class, new SoundDeserializer());
+        return gson.create();
+    }
+
+    private static URL url(String url) {
+        try {
+            return new URL(url);
+        } catch(MalformedURLException e) {
+            throw new AssertionError(e);
+        }
+    }
+    private static URI uri(String uri) {
+        try {
+            return new URI(uri);
+        } catch(URISyntaxException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public boolean areSoundEventsLoaded() {
+        return soundNameToEvent != null;
+    }
+
+    public Optional<String> getSoundEvent(String soundPath) {
+        String baseSound = soundPath.startsWith("minecraft/") ? soundPath.substring("minecraft/".length()) : soundPath;
+        return soundNameToEvent == null ? Optional.empty() : Optional.ofNullable(soundNameToEvent.get(baseSound));
+    }
+
+}

--- a/core/src/main/java/dev/geco/gmusic/service/converter/NBSConverter.java
+++ b/core/src/main/java/dev/geco/gmusic/service/converter/NBSConverter.java
@@ -162,10 +162,7 @@ public class NBSConverter {
 				String sound = customInstrument.getSound();
 				gnbsStruct.set("Song.Content.Instruments." + instrument, sound);
 				gnbsStruct.set("Song.Content.InstrumentKeys." + instrument, customInstrument.getInstrumentKey());
-				String trimmedSound = sound;
-				int idx = trimmedSound.lastIndexOf('/');
-				if(idx >= 0) trimmedSound = trimmedSound.substring(idx + 1);
-				if(!trimmedSound.contains(".")) gMusicMain.getLogger().warning("Possibly unknown custom instrument '" + sound + "' in song '" + id + "'");
+				if(gMusicMain.getSoundEventService().areSoundEventsLoaded() && !customInstrument.isKnownSoundEvent() && !sound.isBlank()) gMusicMain.getLogger().warning("Unknown custom instrument '" + sound + "' in song '" + id + "'");
 			}
 
 			gnbsStruct.set("Song.Content.Main", gnbsContent);

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -9,6 +9,9 @@ Options:
   # Plugin sends update notifications
   check-for-update: true
 
+  # Downloads a list of all sounds if not already downloaded
+  download-sound-events: true
+
   Sound:
     # Defines whether the extended note range should be used for sounds (requires resource pack for players)
     extened-range: true


### PR DESCRIPTION
Many custom instruments are defined as client-side sound paths, such as `dig/sand1` (path in Minecraft assets `sounds` directory) or `minecraft/dig/sand1` (default NBS import directory). However, servers do not have access to these sounds, only [sound events](https://minecraft.wiki/w/Sounds.json#Server-side_sound_events) such as `minecraft:block.sand.break`.

This PR (if enabled) fetches [sounds.json](https://minecraft.wiki/w/Sounds.json) for the current Minecraft version and uses it to convert client-side sound paths to server-side sound events, allowing many more custom instruments to be played without having to manually edit the files.